### PR TITLE
Refactor: User 엔티티 수정 및 연관 도메인 수정 (#52)

### DIFF
--- a/backend/src/main/java/com/bookbook/domain/review/service/ReviewService.java
+++ b/backend/src/main/java/com/bookbook/domain/review/service/ReviewService.java
@@ -119,7 +119,7 @@ public class ReviewService {
         // 본인이 해당 도서를 대여했는지 확인
         boolean isBorrower = rentListRepository.findByRentId(rentId)
                 .stream()
-                .anyMatch(rl -> rl.getBorrowerUser().getId().equals(borrowerId));
+                .anyMatch(rl -> rl.getBorrowerUser().getId() == borrowerId);
 
         if (!isBorrower) {
             throw new IllegalArgumentException("해당 도서를 대여한 사용자만 리뷰를 작성할 수 있습니다.");

--- a/backend/src/main/java/com/bookbook/domain/suspend/service/SuspendedUserService.kt
+++ b/backend/src/main/java/com/bookbook/domain/suspend/service/SuspendedUserService.kt
@@ -96,7 +96,7 @@ class SuspendedUserService(
      * @throws ServiceException (409) 해당 유저가 이미 정지되어 있을 때
      */
     private fun checkUserIsSuspended(user: User) {
-        if (user.isSuspended()) {
+        if (user.isSuspended) {
             throw ServiceException("409-1", "이 유저는 이미 정지 중입니다.")
         }
     }

--- a/backend/src/main/java/com/bookbook/domain/user/dto/UserBaseDto.java
+++ b/backend/src/main/java/com/bookbook/domain/user/dto/UserBaseDto.java
@@ -28,8 +28,8 @@ public record UserBaseDto(
                 .nickname(user.getNickname())
                 .email(user.getEmail())
                 .rating(user.getRating())
-                .createdAt(user.getCreateAt())
-                .updatedAt(user.getUpdateAt())
+                .createdAt(user.getCreatedDate())
+                .updatedAt(user.getModifiedDate())
                 .userStatus(user.getUserStatus())
                 .role(user.getRole())
                 .build();

--- a/backend/src/main/java/com/bookbook/domain/user/dto/UserProfileResponseDto.kt
+++ b/backend/src/main/java/com/bookbook/domain/user/dto/UserProfileResponseDto.kt
@@ -8,15 +8,10 @@ data class UserProfileResponseDto(
     val mannerScore: Double,
     val mannerScoreCount: Int
 ) {
-    companion object {
-        @JvmStatic
-        fun from(user: User, mannerScore: Double, mannerScoreCount: Int): UserProfileResponseDto {
-            return UserProfileResponseDto(
-                userId = user.id!!,
-                nickname = user.nickname,
-                mannerScore = mannerScore,
-                mannerScoreCount = mannerScoreCount
-            )
-        }
-    }
+    constructor(user: User, mannerScore: Double, mannerScoreCount: Int) : this(
+        userId = user.id,
+        nickname = user.nickname,
+        mannerScore = mannerScore,
+        mannerScoreCount = mannerScoreCount
+    )
 }

--- a/backend/src/main/java/com/bookbook/domain/user/dto/UserResponseDto.kt
+++ b/backend/src/main/java/com/bookbook/domain/user/dto/UserResponseDto.kt
@@ -26,7 +26,7 @@ data class UserResponseDto(
         rating = user.rating,
         role = user.role,
         userStatus = user.userStatus,
-        createAt = user.createAt,
+        createAt = user.createdDate,
         isRegistrationCompleted = user.isRegistrationCompleted()
     )
 }

--- a/backend/src/main/java/com/bookbook/domain/user/entity/User.kt
+++ b/backend/src/main/java/com/bookbook/domain/user/entity/User.kt
@@ -3,24 +3,16 @@ package com.bookbook.domain.user.entity
 import com.bookbook.domain.suspend.entity.SuspendedUser
 import com.bookbook.domain.user.enums.Role
 import com.bookbook.domain.user.enums.UserStatus
-import com.bookbook.global.entity.BaseEntity
+import com.bookbook.global.jpa.entity.BaseEntity
 import jakarta.persistence.*
-import jakarta.validation.constraints.Max
-import jakarta.validation.constraints.Min
-import org.springframework.data.annotation.CreatedDate
-import org.springframework.data.annotation.LastModifiedDate
 import org.springframework.data.jpa.domain.support.AuditingEntityListener
 import java.time.LocalDateTime
 
 @Entity
 @Table(name = "users")
 @EntityListeners(AuditingEntityListener::class)
+@AttributeOverride(name = "id", column = Column(name = "user_id"))
 class User(
-    @Id
-    @Column(name = "user_id")
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    var id: Long? = null,
-
     @Column(name = "username", unique = true, nullable = false)
     var username: String,
 
@@ -36,51 +28,41 @@ class User(
     @Column(name = "address", nullable = true)
     var address: String? = null,
 
-    @Min(0)
-    @Max(5)
-    @Column(name = "rating", nullable = false)
-    var rating: Float = 0.0f,
-
     @Enumerated(EnumType.STRING)
     @Column(name = "role", nullable = false)
     var role: Role = Role.USER,
 
+    @Column(name = "registration_completed", nullable = false)
+    var registrationCompleted: Boolean = false
+) : BaseEntity() {
+
+    @Column(name = "rating", nullable = false)
+    var rating: Float = 0.0f
+
+    var suspendedAt: LocalDateTime? = null
+
+    var resumedAt: LocalDateTime? = null
+
     @Enumerated(EnumType.STRING)
     @Column(name = "user_status", nullable = false)
-    var userStatus: UserStatus = UserStatus.ACTIVE,
-
-    @CreatedDate
-    var createAt: LocalDateTime? = null,
-
-    @LastModifiedDate
-    var updateAt: LocalDateTime? = null,
-
-    var suspendedAt: LocalDateTime? = null,
-
-    var resumedAt: LocalDateTime? = null,
-
-    @Column(name = "registration_completed", nullable = false)
-    var registrationCompleted: Boolean = false,
-) : BaseEntity() {
+    var userStatus: UserStatus = UserStatus.ACTIVE
 
     @OneToMany(mappedBy = "user", cascade = [CascadeType.ALL])
     val suspends: MutableList<SuspendedUser> = mutableListOf()
 
-    fun changeUserStatus(userStatus: UserStatus) {
-        this.userStatus = userStatus
-    }
-
     fun changeRating(rating: Float) {
-        if (rating < 0 || rating > 5) {
+        if (rating !in 0.0..5.0) {
             throw IllegalArgumentException("Rating must be between 0 and 5")
         }
         this.rating = rating
     }
 
     fun suspend(periodDays: Int) {
+        val now = LocalDateTime.now()
+
         this.userStatus = UserStatus.SUSPENDED
-        this.suspendedAt = LocalDateTime.now()
-        this.resumedAt = suspendedAt?.plusDays(periodDays.toLong())
+        this.suspendedAt = now
+        this.resumedAt = now.plusDays(periodDays.toLong())
     }
 
     fun resume() {
@@ -89,17 +71,11 @@ class User(
         this.resumedAt = null
     }
 
-    fun isSuspended(): Boolean {
-        return userStatus == UserStatus.SUSPENDED
-    }
-
-    fun changeUsername(username: String) {
-        this.username = username
-    }
+    val isSuspended: Boolean
+            get() = this.userStatus == UserStatus.SUSPENDED
 
     // 자바 코드와의 호환성을 위한 수동 구현
     fun isRegistrationCompleted(): Boolean {
         return this.registrationCompleted
     }
-
 }

--- a/backend/src/main/java/com/bookbook/domain/user/enums/Role.kt
+++ b/backend/src/main/java/com/bookbook/domain/user/enums/Role.kt
@@ -1,8 +1,5 @@
 package com.bookbook.domain.user.enums
 
-import lombok.Getter
-
-@Getter
 enum class Role {
     USER,
     ADMIN

--- a/backend/src/main/java/com/bookbook/domain/user/enums/UserStatus.kt
+++ b/backend/src/main/java/com/bookbook/domain/user/enums/UserStatus.kt
@@ -1,8 +1,5 @@
 package com.bookbook.domain.user.enums
 
-import lombok.Getter
-
-@Getter
 enum class UserStatus {
     ACTIVE,
     INACTIVE,

--- a/backend/src/main/java/com/bookbook/domain/user/repository/UserRepository.kt
+++ b/backend/src/main/java/com/bookbook/domain/user/repository/UserRepository.kt
@@ -19,7 +19,7 @@ interface UserRepository : JpaRepository<User, Long> {
         SELECT u FROM User u WHERE
         (:status IS NULL OR u.userStatus in :status) AND
         (:userId IS NULL OR u.id = :userId)
-        ORDER BY u.createAt DESC
+        ORDER BY u.createdDate DESC
     """
     )
     fun findFilteredUsers(

--- a/backend/src/main/java/com/bookbook/domain/user/service/UserService.kt
+++ b/backend/src/main/java/com/bookbook/domain/user/service/UserService.kt
@@ -44,9 +44,7 @@ class UserService(
                 email = adminEmail,
                 nickname = "관리자",
                 address = "서울시 강남구",
-                rating = 5.0f,
                 role = Role.ADMIN,
-                userStatus = UserStatus.ACTIVE,
                 registrationCompleted = true
             )
             userRepository.save(adminUser)
@@ -136,8 +134,8 @@ class UserService(
         }
 
         user.apply {
-            changeUserStatus(UserStatus.INACTIVE)
-            changeUsername("${username}_deleted_${UUID.randomUUID()}")
+            userStatus = UserStatus.INACTIVE
+            username = "${username}_deleted_${UUID.randomUUID()}"
             email = email?.let { "${it}_deleted_${UUID.randomUUID()}" }
             nickname = null
             address = null
@@ -165,12 +163,6 @@ class UserService(
                     username = username,
                     email = email,
                     password = passwordEncoder.encode(UUID.randomUUID().toString()),
-                    nickname = null,
-                    address = null,
-                    rating = 0.0f,
-                    role = Role.USER,
-                    userStatus = UserStatus.ACTIVE,
-                    registrationCompleted = false
                 )
                 userRepository.save(newUser)
                 newUser
@@ -186,11 +178,11 @@ class UserService(
         val user = getByIdOrThrow(userId)
 
         return if (user.role == Role.ADMIN) {
-            UserProfileResponseDto.from(user, 5.0, 0)
+            UserProfileResponseDto(user, 5.0, 0)
         } else {
             val averageRating = reviewRepository.findAverageRatingByRevieweeId(userId).orElse(0.0)
             val mannerScoreCount = reviewRepository.countByRevieweeId(userId)
-            UserProfileResponseDto.from(user, averageRating, mannerScoreCount.toInt())
+            UserProfileResponseDto(user, averageRating, mannerScoreCount.toInt())
         }
     }
 }


### PR DESCRIPTION
## 💡 변경 사항
- [x] User 엔티티 수정
  * `global.jpa.entity.BaseEntity`로 상속 변경
  * 리포지토리, 서비스, DTO 등 수정
- [x] User 도메인 Enum 에 `@Getter` 제거

---
### ✅ 특이 사항
- User 엔티티를 건드렸기 때문에 다른 도메인에 영향이 있을 수도 있습니다. 문제 발견 시 문의해주세요

---

### 🔗 관련 이슈
closed #52 