### PR TITLE
Fix: 대여 도메인 수정

### DIFF
--- a/backend/src/main/java/com/bookbook/domain/rent/controller/BookSearchController.kt
+++ b/backend/src/main/java/com/bookbook/domain/rent/controller/BookSearchController.kt
@@ -1,6 +1,6 @@
 package com.bookbook.domain.rent.controller
 
-import com.bookbook.domain.rent.dto.BookSearchResponseDto
+import com.bookbook.domain.rent.dto.response.BookSearchResponseDto
 import com.bookbook.domain.rent.service.BookSearchService
 import io.swagger.v3.oas.annotations.Operation
 import org.springframework.http.ResponseEntity

--- a/backend/src/main/java/com/bookbook/domain/rent/controller/RentAdminController.kt
+++ b/backend/src/main/java/com/bookbook/domain/rent/controller/RentAdminController.kt
@@ -9,7 +9,6 @@ import com.bookbook.global.jpa.dto.response.PageResponseDto
 import com.bookbook.global.rsdata.RsData
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
-import org.springframework.context.annotation.Lazy
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Pageable
 import org.springframework.http.ResponseEntity
@@ -21,7 +20,7 @@ import org.springframework.web.bind.annotation.*
 @RequestMapping("/api/v1/admin/rent")
 @Tag(name = "RentAdminController", description = "어드민 전용 대여 게시글 컨트롤러")
 class RentAdminController(
-    @Lazy private val rentService: RentService
+    private val rentService: RentService
 ) {
 
     /**

--- a/backend/src/main/java/com/bookbook/domain/rent/controller/RentAdminController.kt
+++ b/backend/src/main/java/com/bookbook/domain/rent/controller/RentAdminController.kt
@@ -43,14 +43,14 @@ class RentAdminController(
         @RequestParam(defaultValue = "10") size: Int,
         @RequestParam(required = false) status: List<RentStatus>?,
         @RequestParam(required = false) userId: Long?
-    ): ResponseEntity<RsData<PageResponseDto<RentSimpleResponseDto>?>> {
+    ): ResponseEntity<RsData<PageResponseDto<RentSimpleResponseDto>>> {
         val pageable: Pageable = PageRequest.of(page - 1, size)
 
         val rentHistoryPage = rentService.getRentsPage(pageable, status, userId)
         val response = PageResponseDto(rentHistoryPage)
 
         return ResponseEntity.ok(
-            RsData.of(
+            RsData(
                 "200-1",
                 "${rentHistoryPage.totalElements}개의 글을 발견했습니다.",
                 response
@@ -68,11 +68,11 @@ class RentAdminController(
     @Operation(summary = "단일 대여 게시글 상세 조회")
     fun getRentDetail(
         @PathVariable id: Long
-    ): ResponseEntity<RsData<RentDetailResponseDto?>> {
+    ): ResponseEntity<RsData<RentDetailResponseDto>> {
         val responseDto = rentService.getRentPostDetail(id)
 
         return ResponseEntity.ok(
-            RsData.of("200-1", "$id 번 글 상태 변경 완료", responseDto)
+            RsData("200-1", "$id 번 글 상태 변경 완료", responseDto)
         )
     }
 
@@ -87,11 +87,11 @@ class RentAdminController(
     fun changeRentStatus(
         @PathVariable id: Long,
         @RequestBody status: ChangeRentStatusRequestDto
-    ): ResponseEntity<RsData<RentDetailResponseDto?>> { // 경로 변수로 전달된 id를 사용
-        val responseDto = rentService.modifyRentPageStatus(id, status)
+    ): ResponseEntity<RsData<RentDetailResponseDto>> { // 경로 변수로 전달된 id를 사용
+        val responseDto = rentService.modifyRentPageStatus(id, status.status)
 
         return ResponseEntity.ok(
-            RsData.of("200-1", "$id 번 글 상태 변경 완료", responseDto)
+            RsData("200-1", "$id 번 글 상태 변경 완료", responseDto)
         )
     }
 
@@ -103,14 +103,12 @@ class RentAdminController(
      */
     @PatchMapping("/{id}/restore")
     @Operation(summary = "대여 게시글 복구")
-    fun restoreRentPage(@PathVariable id: Long): ResponseEntity<RsData<RentDetailResponseDto?>> { // 경로 변수로 전달된 id를 사용
+    fun restoreRentPage(@PathVariable id: Long): ResponseEntity<RsData<RentDetailResponseDto>> { // 경로 변수로 전달된 id를 사용
         val responseDto = rentService.restoreRentPage(id)
 
         return ResponseEntity.ok(
-            RsData.of(
-                "200-1",
-                "$id 번 글 복구 완료",
-                responseDto
+            RsData(
+                "200-1", "$id 번 글 복구 완료", responseDto
             )
         )
     }

--- a/backend/src/main/java/com/bookbook/domain/rent/controller/RentAdminController.kt
+++ b/backend/src/main/java/com/bookbook/domain/rent/controller/RentAdminController.kt
@@ -96,19 +96,6 @@ class RentAdminController(
     }
 
     /**
-     * 대여 게시글 하나를 SOFT DELETE합니다.
-     *
-     * @param id 대여 게시글 ID
-     * @return 없음
-     */
-    @DeleteMapping("/{id}")
-    @Operation(summary = "대여 게시글 영구 삭제")
-    fun deleteRentPage(@PathVariable id: Long): ResponseEntity<RsData<Void?>> { // 경로 변수로 전달된 id를 사용
-        rentService.removeRentPage(id)
-        return ResponseEntity.ok(RsData.of("200-1", "$id 번 글 삭제 완료"))
-    }
-
-    /**
      * SOFT DELETE된 대여 게시글 하나를 복구합니다.
      *
      * @param id 대여 게시글 ID

--- a/backend/src/main/java/com/bookbook/domain/rent/controller/RentController.kt
+++ b/backend/src/main/java/com/bookbook/domain/rent/controller/RentController.kt
@@ -1,7 +1,7 @@
 package com.bookbook.domain.rent.controller
 
-import com.bookbook.domain.rent.dto.RentRequestDto
-import com.bookbook.domain.rent.dto.RentResponseDto
+import com.bookbook.domain.rent.dto.request.RentRequestDto
+import com.bookbook.domain.rent.dto.response.RentResponseDto
 import com.bookbook.domain.rent.service.RentService
 import com.bookbook.global.security.CustomOAuth2User
 import io.swagger.v3.oas.annotations.Operation

--- a/backend/src/main/java/com/bookbook/domain/rent/controller/RentController.kt
+++ b/backend/src/main/java/com/bookbook/domain/rent/controller/RentController.kt
@@ -3,9 +3,12 @@ package com.bookbook.domain.rent.controller
 import com.bookbook.domain.rent.dto.request.RentRequestDto
 import com.bookbook.domain.rent.dto.response.RentResponseDto
 import com.bookbook.domain.rent.service.RentService
+import com.bookbook.global.exception.ServiceException
+import com.bookbook.global.rsdata.RsData
 import com.bookbook.global.security.CustomOAuth2User
 import io.swagger.v3.oas.annotations.Operation
 import jakarta.validation.Valid
+import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.*
 
@@ -57,4 +60,26 @@ class RentController(
 
     // borrowerUserId : 대여 받은 사용자 ID
     // rentID : 대여 게시글 ID
+
+    /**
+     * 대여 게시글 하나를 SOFT DELETE합니다.
+     *
+     * @param id 대여 게시글 ID
+     * @return 없음
+     */
+    @DeleteMapping("/{id}")
+    @Operation(summary = "대여 게시글 삭제 (Soft Delete)")
+    fun deleteRentPage(
+        @PathVariable id: Long,
+        @AuthenticationPrincipal customOAuth2User: CustomOAuth2User?
+    ): ResponseEntity<RsData<Void>> { // 경로 변수로 전달된 id를 사용
+        if (customOAuth2User == null)
+            throw ServiceException("401-1", "로그인이 필요합니다.")
+
+        rentService.removeRentPage(customOAuth2User.userId, id)
+
+        return ResponseEntity.ok(
+            RsData("200-1", "$id 번 글 삭제 완료")
+        )
+    }
 }

--- a/backend/src/main/java/com/bookbook/domain/rent/dto/request/RentRequestDto.kt
+++ b/backend/src/main/java/com/bookbook/domain/rent/dto/request/RentRequestDto.kt
@@ -1,4 +1,4 @@
-package com.bookbook.domain.rent.dto
+package com.bookbook.domain.rent.dto.request
 
 import com.bookbook.domain.rent.entity.RentStatus
 import jakarta.validation.constraints.NotBlank

--- a/backend/src/main/java/com/bookbook/domain/rent/dto/response/BookSearchResponseDto.kt
+++ b/backend/src/main/java/com/bookbook/domain/rent/dto/response/BookSearchResponseDto.kt
@@ -1,4 +1,4 @@
-package com.bookbook.domain.rent.dto
+package com.bookbook.domain.rent.dto.response
 
 // 25.08.28 현준
 // Aladin API의 응답 데이터를 기반으로 필요한 필드만 추출하여 정의

--- a/backend/src/main/java/com/bookbook/domain/rent/dto/response/RentAvailableResponseDto.kt
+++ b/backend/src/main/java/com/bookbook/domain/rent/dto/response/RentAvailableResponseDto.kt
@@ -1,4 +1,4 @@
-package com.bookbook.domain.rent.dto
+package com.bookbook.domain.rent.dto.response
 
 import com.bookbook.domain.rent.entity.Rent
 import org.springframework.data.domain.Page
@@ -34,7 +34,7 @@ data class RentAvailableResponseDto(
             // Rent 엔티티와 User 엔티티로부터 BookInfo 생성 (Null Safe 처리)
             fun from(rent: Rent, lenderNickname: String?): BookInfo {
                 return BookInfo(
-                    id = rent.id?.toLong(),
+                    id = rent.id,
                     bookTitle = rent.bookTitle,
                     author = rent.author,
                     publisher = rent.publisher,
@@ -42,13 +42,13 @@ data class RentAvailableResponseDto(
                     bookImage = rent.bookImage,
                     address = rent.address,
                     category = rent.category,
-                    rentStatus = rent.rentStatus?.description,
+                    rentStatus = rent.rentStatus.description,
                     lenderUserId = rent.lenderUserId,
                     lenderNickname = lenderNickname,
                     title = rent.title,
                     contents = rent.contents,
-                    createdDate = rent.createdDate?.toString(),
-                    modifiedDate = rent.modifiedDate?.toString()
+                    createdDate = rent.createdDate.toString(),
+                    modifiedDate = rent.modifiedDate.toString()
                 )
             }
         }

--- a/backend/src/main/java/com/bookbook/domain/rent/dto/response/RentDetailResponseDto.kt
+++ b/backend/src/main/java/com/bookbook/domain/rent/dto/response/RentDetailResponseDto.kt
@@ -8,43 +8,38 @@ import java.time.LocalDateTime
 // 대여 게시글의 상세 정보를 담는 DTO.
 data class RentDetailResponseDto(
     val id: Long,                           // 글 ID
-    val lenderUserId: Long?,               // 대여자 ID
-    val title: String?,                    // 글 제목
-    val bookCondition: String?,            // 책 상태
-    val bookImage: String?,                // 글쓴이가 올린 책 이미지 URL
-    val address: String?,                  // 사용자 주소
-    val contents: String?,                 // 대여 내용
-    val rentStatus: RentStatus?,           // 대여 상태
+    val lenderUserId: Long,               // 대여자 ID
+    val title: String,                    // 글 제목
+    val bookCondition: String,            // 책 상태
+    val bookImage: String,                // 글쓴이가 올린 책 이미지 URL
+    val address: String,                  // 사용자 주소
+    val contents: String,                 // 대여 내용
+    val rentStatus: RentStatus,           // 대여 상태
 
     // 책 정보
-    val bookTitle: String?,                // 책 제목
-    val author: String?,                   // 책 저자
-    val publisher: String?,                // 책 출판사
-    val category: String?,                 // 책 카테고리
-    val description: String?,              // 책 설명
-    val createdDate: LocalDateTime?,       // 생성일
-    val modifiedDate: LocalDateTime?       // 수정일
+    val bookTitle: String,                // 책 제목
+    val author: String,                   // 책 저자
+    val publisher: String,                // 책 출판사
+    val category: String,                 // 책 카테고리
+    val description: String,              // 책 설명
+    val createdDate: LocalDateTime,       // 생성일
+    val modifiedDate: LocalDateTime       // 수정일
 ) {
-    companion object {
-        // Rent Entity로부터 DTO 생성하는 factory 메서드
-        fun from(rent: Rent): RentDetailResponseDto {
-            return RentDetailResponseDto(
-                id = rent.id,
-                lenderUserId = rent.lenderUserId,
-                title = rent.title,
-                bookCondition = rent.bookCondition,
-                bookImage = rent.bookImage,
-                address = rent.address,
-                contents = rent.contents,
-                rentStatus = rent.rentStatus,
-                bookTitle = rent.bookTitle,
-                author = rent.author,
-                publisher = rent.publisher,
-                category = rent.category,
-                description = rent.description,
-                createdDate = rent.createdDate,
-                modifiedDate = rent.modifiedDate
-            )
-        }
-    }
+    constructor(rent: Rent): this(
+        id = rent.id,
+        lenderUserId = rent.lenderUserId,
+        title = rent.title,
+        bookCondition = rent.bookCondition,
+        bookImage = rent.bookImage,
+        address = rent.address,
+        contents = rent.contents,
+        rentStatus = rent.rentStatus,
+        bookTitle = rent.bookTitle,
+        author = rent.author,
+        publisher = rent.publisher,
+        category = rent.category,
+        description = rent.description,
+        createdDate = rent.createdDate,
+        modifiedDate = rent.modifiedDate
+    )
 }

--- a/backend/src/main/java/com/bookbook/domain/rent/dto/response/RentListResponseDto.kt
+++ b/backend/src/main/java/com/bookbook/domain/rent/dto/response/RentListResponseDto.kt
@@ -1,4 +1,4 @@
-package com.bookbook.domain.rent.dto
+package com.bookbook.domain.rent.dto.response
 
 import com.bookbook.domain.rent.entity.Rent
 import java.nio.file.Files

--- a/backend/src/main/java/com/bookbook/domain/rent/dto/response/RentResponseDto.kt
+++ b/backend/src/main/java/com/bookbook/domain/rent/dto/response/RentResponseDto.kt
@@ -1,5 +1,4 @@
-// 25.08.03 현준
-package com.bookbook.domain.rent.dto
+package com.bookbook.domain.rent.dto.response
 
 import com.bookbook.domain.rent.entity.RentStatus
 import java.time.LocalDateTime

--- a/backend/src/main/java/com/bookbook/domain/rent/dto/response/RentSimpleResponseDto.kt
+++ b/backend/src/main/java/com/bookbook/domain/rent/dto/response/RentSimpleResponseDto.kt
@@ -8,29 +8,24 @@ import java.time.LocalDateTime
 // 대여 게시글의 간단한 정보를 담는 DTO.
 data class RentSimpleResponseDto(
     val id: Long,
-    val lenderUserId: Long?,
-    val status: RentStatus?,
-    val bookCondition: String?,
-    val bookTitle: String?,
-    val author: String?,
-    val publisher: String?,
-    val createdDate: LocalDateTime?,
-    val modifiedDate: LocalDateTime?
+    val lenderUserId: Long,
+    val status: RentStatus,
+    val bookCondition: String,
+    val bookTitle: String,
+    val author: String,
+    val publisher: String,
+    val createdDate: LocalDateTime,
+    val modifiedDate: LocalDateTime
 ) {
-    companion object {
-        // Rent Entity로부터 DTO 생성하는 factory 메서드
-        fun from(rent: Rent): RentSimpleResponseDto {
-            return RentSimpleResponseDto(
-                id = rent.id,
-                lenderUserId = rent.lenderUserId,
-                status = rent.rentStatus,
-                bookCondition = rent.bookCondition,
-                bookTitle = rent.bookTitle,
-                author = rent.author,
-                publisher = rent.publisher,
-                createdDate = rent.createdDate,
-                modifiedDate = rent.modifiedDate
-            )
-        }
-    }
+    constructor(rent: Rent) : this(
+        id = rent.id,
+        lenderUserId = rent.lenderUserId,
+        status = rent.rentStatus,
+        bookCondition = rent.bookCondition,
+        bookTitle = rent.bookTitle,
+        author = rent.author,
+        publisher = rent.publisher,
+        createdDate = rent.createdDate,
+        modifiedDate = rent.modifiedDate
+    )
 }

--- a/backend/src/main/java/com/bookbook/domain/rent/service/BookSearchService.kt
+++ b/backend/src/main/java/com/bookbook/domain/rent/service/BookSearchService.kt
@@ -1,6 +1,6 @@
 package com.bookbook.domain.rent.service
 
-import com.bookbook.domain.rent.dto.BookSearchResponseDto
+import com.bookbook.domain.rent.dto.response.BookSearchResponseDto
 import com.bookbook.global.exception.ServiceException
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.slf4j.LoggerFactory
@@ -17,7 +17,7 @@ class BookSearchService {
 
     private val restTemplate = RestTemplate()
     private val objectMapper = ObjectMapper()
-    
+
     companion object {
         private val log = LoggerFactory.getLogger(BookSearchService::class.java)
     }

--- a/backend/src/main/java/com/bookbook/domain/rent/service/RentService.kt
+++ b/backend/src/main/java/com/bookbook/domain/rent/service/RentService.kt
@@ -2,11 +2,10 @@ package com.bookbook.domain.rent.service
 
 import com.bookbook.domain.notification.enums.NotificationType
 import com.bookbook.domain.notification.service.NotificationService
-import com.bookbook.domain.rent.dto.RentAvailableResponseDto
-import com.bookbook.domain.rent.dto.RentRequestDto
-import com.bookbook.domain.rent.dto.RentResponseDto
-import com.bookbook.domain.rent.dto.request.ChangeRentStatusRequestDto
+import com.bookbook.domain.rent.dto.request.RentRequestDto
+import com.bookbook.domain.rent.dto.response.RentAvailableResponseDto
 import com.bookbook.domain.rent.dto.response.RentDetailResponseDto
+import com.bookbook.domain.rent.dto.response.RentResponseDto
 import com.bookbook.domain.rent.dto.response.RentSimpleResponseDto
 import com.bookbook.domain.rent.entity.Rent
 import com.bookbook.domain.rent.entity.RentStatus

--- a/backend/src/main/java/com/bookbook/domain/rent/service/RentService.kt
+++ b/backend/src/main/java/com/bookbook/domain/rent/service/RentService.kt
@@ -93,7 +93,7 @@ class RentService(
             .orElseThrow { ServiceException("404-2", "해당 대여글을 찾을 수 없습니다.") }
 
         // ID로 대여자 정보 조회
-        val rentUser = userRepository.findById(rent.lenderUserId!!)
+        val rentUser = userRepository.findById(rent.lenderUserId)
             .orElseThrow { ServiceException("404-3", "해당 대여자를 찾을 수 없습니다.") }
 
         // 대여자가 작성한 글 갯수 조회
@@ -145,9 +145,7 @@ class RentService(
             .orElseThrow { ServiceException("404-2", "해당 대여글을 찾을 수 없습니다.") }
 
         // 글 작성자와 현재 로그인한 사용자가 일치하는지 확인
-        if (rent.lenderUserId != userId) {
-            throw ServiceException("403", "해당 대여글을 수정할 권한이 없습니다.")
-        }
+        isSameAuthor(userId, rent.lenderUserId )
 
         // Rent 엔티티 업데이트 (Kotlin의 mutable properties 활용)
         rent.apply {
@@ -261,41 +259,49 @@ class RentService(
         userId: Long?
     ): Page<RentSimpleResponseDto> {
         return rentRepository.findFilteredRentHistory(pageable, status, userId)
-            .map(RentSimpleResponseDto::from)
+            .map{ RentSimpleResponseDto(it) }
     }
 
     /**
      * 대여 게시글의 상태를 변경합니다.
      *
      * @param rentId 대여 게시글 ID
-     * @param requestDto 대여 게시글 상태 요청 본문
+     * @param newStatus 대여 게시글 상태 요청 본문
      * @return 수정된 대여 게시글 상세 정보
      */
     @Transactional
-    fun modifyRentPageStatus(rentId: Long, requestDto: ChangeRentStatusRequestDto): RentDetailResponseDto {
+    fun modifyRentPageStatus(rentId: Long, newStatus: RentStatus): RentDetailResponseDto {
         val rent = rentRepository.findById(rentId)
             .orElseThrow { ServiceException("404-2", "해당 대여글을 찾을 수 없습니다.") }
 
         checkRentPostIsDeleted(rent)
 
-        if (rent.rentStatus == requestDto.status) {
+        if (rent.rentStatus == newStatus) {
             throw ServiceException("409-1", "현재 상태와 동일합니다.")
         }
 
-        rent.rentStatus = requestDto.status
-        return RentDetailResponseDto.from(rent)
+        rent.rentStatus = newStatus
+        return RentDetailResponseDto(rent)
     }
 
     /**
      * 대여 게시글을 SOFT DELETE 합니다.
      *
+     * @param userId 작성한 유저의 ID
      * @param rentId 대여 게시글의 ID
      * @throws ServiceException (404) 해당 대여 게시글이 존재하지 않을 때
      */
     @Transactional
-    fun removeRentPage(rentId: Long) {
+    fun removeRentPage(userId: Long, rentId: Long) {
+        val executor = userRepository.findById(userId)
+            .orElseThrow { ServiceException("404-1", "존재하지 않는 유저입니다.") }
+
         val rent = rentRepository.findById(rentId)
-            .orElseThrow { ServiceException("404-2", "해당 대여글은 찾을 수 없습니다.") }
+            .orElseThrow { ServiceException("404-2", "해당 대여글을 찾을 수 없습니다.") }
+
+        if (!executor.isAdmin) {
+            isSameAuthor(userId, rent.lenderUserId)
+        }
 
         checkRentPostIsDeleted(rent)
 
@@ -313,14 +319,15 @@ class RentService(
     @Transactional
     fun restoreRentPage(rentId: Long): RentDetailResponseDto {
         val rent = rentRepository.findById(rentId)
-            .orElseThrow { ServiceException("404-2", "해당 대여글은 찾을 수 없습니다.") }
+            .orElseThrow { ServiceException("404-2", "해당 대여글을 찾을 수 없습니다.") }
 
         if (rent.rentStatus != RentStatus.DELETED) {
             throw ServiceException("409-1", "해당 글은 삭제된 상태가 아닙니다")
         }
 
         rent.rentStatus = RentStatus.AVAILABLE
-        return RentDetailResponseDto.from(rent)
+
+        return RentDetailResponseDto(rent)
     }
 
     /**
@@ -335,7 +342,20 @@ class RentService(
         val rent = rentRepository.findById(rentId)
             .orElseThrow { ServiceException("404-2", "해당 대여글을 찾을 수 없습니다.") }
 
-        return RentDetailResponseDto.from(rent)
+        return RentDetailResponseDto(rent)
+    }
+
+    /**
+     * 대여 글 작성자와 요청자의 Id를 비교하여
+     * 필요 시 예외를 throw 합니다.
+     *
+     * @param executorId 요청을 실행한 유저의 Id
+     * @param authorId 게시글 작성자 Id
+     * @throws ServiceException (403)
+     */
+    private fun isSameAuthor(executorId: Long, authorId: Long) {
+        if (executorId != authorId)
+            throw ServiceException("403", "해당 대여글을 수정할 권한이 없습니다.")
     }
 
     /**
@@ -346,7 +366,7 @@ class RentService(
      */
     private fun checkRentPostIsDeleted(rent: Rent) {
         if (rent.rentStatus == RentStatus.DELETED) {
-            throw ServiceException("404-1", "이미 해당 글은 삭제되었습니다.")
+            throw ServiceException("404-1", "해당 글은 삭제되었습니다.")
         }
     }
 }

--- a/frontend/src/app/admin/dashboard/_components/post/manage/postDetailModal.tsx
+++ b/frontend/src/app/admin/dashboard/_components/post/manage/postDetailModal.tsx
@@ -26,7 +26,7 @@ export function PostDetailModal({
   const [confirmAction, setConfirmAction] = useState<"delete" | "updateStatus" | "restore" | null>(null);
   const initialRentStatus = currentPost?.rentStatus ? currentPost.rentStatus : "UNKNOWN";
   const [rentStatusValue, setRentStatusValue] = useState<RentStatus>(initialRentStatus);
-  const isSameStatus = post.rentStatus == rentStatusValue;
+  const isSameStatus = initialRentStatus == rentStatusValue;
   const isDeleted = initialRentStatus === "DELETED";
 
   const rentStatusButtonClassName = isSameStatus
@@ -63,7 +63,7 @@ export function PostDetailModal({
   }
 
   const handlePostDelete = async () => {
-    const response = await fetch(`/api/v1/admin/rent/${currentPost.id}`,
+    const response = await fetch(`/api/v1/bookbook/rent/${currentPost.id}`,
       {
         method: "DELETE",
         headers: {
@@ -228,9 +228,9 @@ export function PostDetailModal({
               </button>
               {!isDeleted && (
                 <button
-                onClick={handleStatusUpdate}
-                disabled={initialRentStatus == rentStatusValue}
-                className={rentStatusButtonClassName}
+                  onClick={handleStatusUpdate}
+                  disabled={initialRentStatus == rentStatusValue}
+                  className={rentStatusButtonClassName}
                 >
                   상태 변경
                 </button>


### PR DESCRIPTION
## 💡 변경 사항
- [x] 대여 도메인 수정
  * DTO 패키지 분리 (request, response)
- [x] 글 삭제 메소드 RentAdminController -> RentController 로 이동
  * 시큐리티 등 권한 문제로 인해 검증 로직 추가
- [x] 대여 글 관리자 페이지에서 글 상태 수정 후 정상적으로 레이아웃이 반영되지 않던 현상 수정
 
---
### ✅ 특이 사항
- Rent 도메인 작업하신 분과 충돌할 가능성이 다분합니다. 이에 지정된 분의 리뷰가 필요할 것 같습니다
- 마이그레이션이 아니기 때문에, Squash Merge로 진행될 예정입니다.

---
### 🔗 관련 이슈
closed #72 