### PR TITLE
Test: 회원 정지 관련 테스트 케이스 추가 (#96)

### DIFF
--- a/backend/src/main/java/com/bookbook/BookbookApplication.kt
+++ b/backend/src/main/java/com/bookbook/BookbookApplication.kt
@@ -1,6 +1,6 @@
 package com.bookbook
 
-import io.github.cdimascio.dotenv.Dotenv
+import com.bookbook.global.util.EnvLoader
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing
@@ -12,13 +12,6 @@ import org.springframework.scheduling.annotation.EnableScheduling
 class BookbookApplication
 
 fun main(args: Array<String>) {
-    try {
-        Dotenv.configure()
-            .ignoreIfMissing()
-            .systemProperties() // 이 한 줄로 기존의 forEach 루프를 대체합니다.
-            .load()
-    } catch (e: Exception) {
-        println(".env 파일 없음 - 기본 설정으로 실행")
-    }
+    EnvLoader.loadEnv()
     runApplication<BookbookApplication>(*args)
 }

--- a/backend/src/main/java/com/bookbook/domain/suspend/controller/SuspendedUserController.kt
+++ b/backend/src/main/java/com/bookbook/domain/suspend/controller/SuspendedUserController.kt
@@ -10,9 +10,6 @@ import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import lombok.RequiredArgsConstructor
-import org.springframework.data.domain.Page
-import org.springframework.data.domain.PageRequest
-import org.springframework.data.domain.Pageable
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 
@@ -47,15 +44,13 @@ class SuspendedUserController (
         @RequestParam(defaultValue = "10") size: Int,
         @RequestParam(required = false) userId: Long?
     ): ResponseEntity<RsData<PageResponseDto<UserSuspendResponseDto>>> {
-        val pageable: Pageable = PageRequest.of(page - 1, size)
+        val histories = suspendedUserService.getSuspendedHistoryPage(page, size, userId)
 
-        val historyPage: Page<UserSuspendResponseDto> =
-            suspendedUserService.getSuspendedHistoryPage(pageable, userId)
-        val response = PageResponseDto(historyPage)
+        val response =  PageResponseDto(histories)
 
         return ResponseEntity.ok(RsData(
             "200-1",
-            "${historyPage.totalElements}개의 정지 이력을 발견했습니다",
+            "${histories.totalElements}개의 정지 이력을 발견했습니다.",
             response
         ))
     }
@@ -72,12 +67,13 @@ class SuspendedUserController (
         @Valid @RequestBody requestDto: UserSuspendRequestDto
     ): ResponseEntity<RsData<UserDetailResponseDto>> {
         val suspendedUser = suspendedUserService.addUserAsSuspended(requestDto)
+
         val userSuspendResponseDto = UserDetailResponseDto(suspendedUser.user)
 
         return ResponseEntity.ok(
             RsData(
                 "200-1",
-                "${suspendedUser.user.username}님을 정지하였습니다",
+                "${suspendedUser.user.username}님을 정지하였습니다.",
                 userSuspendResponseDto
             )
         )
@@ -100,7 +96,7 @@ class SuspendedUserController (
         return ResponseEntity.ok(
             RsData(
                 "200-1",
-                "${userDetailResponseDto.username}님의 정지가 해지되었습니다",
+                "${userDetailResponseDto.username}님의 정지가 해제되었습니다.",
                 userDetailResponseDto
             )
         )

--- a/backend/src/main/java/com/bookbook/domain/suspend/dto/request/UserSuspendRequestDto.kt
+++ b/backend/src/main/java/com/bookbook/domain/suspend/dto/request/UserSuspendRequestDto.kt
@@ -1,7 +1,6 @@
 package com.bookbook.domain.suspend.dto.request
 
-import jakarta.validation.constraints.NotBlank
-import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.*
 
 // 25.08.28 김지훈
 
@@ -13,9 +12,16 @@ import jakarta.validation.constraints.NotNull
  * @param period 정지 기간 (일)
  */
 data class UserSuspendRequestDto(
-    @field:NotNull val userId: Long,
+    @field:NotNull(message = "유저 ID는 필수입니다")
+    @field:Min(value = 1, message = "유효한 유저 ID를 입력해주세요.")
+    val userId: Long,
 
-    @field:NotBlank val reason: String,
+    @field:Size(min = 1, max = 300, message = "정지 사유는 300자를 넘을 수 없습니다")
+    @field:Pattern(regexp = ".*\\S.*", message = "정지 사유를 입력해주세요.")
+    val reason: String,
 
-    @field:NotNull val period: Int
+    @field:NotNull(message = "정지 기간은 필수입니다.")
+    @field:Min(value = 3, message = "정지 기간은 3일 이상이어야 합니다.")
+    @field:Max(value = 73000, message = "정지 기간은 200년을 넘을 수 없습니다.")
+    val period: Int
 )

--- a/backend/src/main/java/com/bookbook/domain/suspend/dto/response/UserSuspendResponseDto.kt
+++ b/backend/src/main/java/com/bookbook/domain/suspend/dto/response/UserSuspendResponseDto.kt
@@ -25,7 +25,7 @@ data class UserSuspendResponseDto(
 ) {
     constructor(suspendedUser: SuspendedUser) : this(
         id = suspendedUser.id,
-        userId = suspendedUser.user.id!!,
+        userId = suspendedUser.user.id,
         name = suspendedUser.user.username,
         reason = suspendedUser.reason,
         suspendedAt = suspendedUser.suspendedAt,

--- a/backend/src/main/java/com/bookbook/domain/suspend/schedule/SuspendedUserScheduler.kt
+++ b/backend/src/main/java/com/bookbook/domain/suspend/schedule/SuspendedUserScheduler.kt
@@ -1,12 +1,11 @@
 package com.bookbook.domain.suspend.schedule
 
-import com.bookbook.domain.user.enums.UserStatus
 import com.bookbook.domain.user.repository.UserRepository
 import org.slf4j.LoggerFactory
+import org.springframework.context.annotation.Profile
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
-import java.time.LocalDateTime
 
 // 25.08.28 김지훈
 
@@ -14,29 +13,31 @@ import java.time.LocalDateTime
  * 정지 관련 스케쥴러
  */
 @Component
+@Profile("!test") // 테스트 환경을 제외하고 작동
 class SuspendedUserScheduler(
     private val userRepository: UserRepository
 ) {
 
-    companion object {
-        private val log = LoggerFactory.getLogger(SuspendedUserScheduler::class.java)
-    }
+    private val log = LoggerFactory.getLogger(this::class.java)
     /**
      * 정지 자동 해제 스케쥴러
      *
      * 일정 주기마다 활동 재개 가능한 유저를 모두 조회하고,
      * 정지를 자동으로 해제합니다.
      *
-     * [[25.08.05]] 한 시간마다 확인
+     * [[25.09.01]] 15분 마다 확인
      */
-    @Scheduled(cron = "0 0 */1 * * *")
+    @Scheduled(cron = "0 */15 * * * *")
     @Transactional
     fun executeScheduledResumingUsers() {
         log.info("자동 정지 해제 스케쥴러 시작")
-        val suspendedUsers = userRepository
-            .findAllByUserStatusAndResumedAtBefore(UserStatus.SUSPENDED, LocalDateTime.now())
 
-        if (suspendedUsers.isEmpty()) return
+        val suspendedUsers = userRepository.findAllPossibleResumedUsers()
+
+        if (suspendedUsers.isEmpty()) {
+            log.info("정지 해제 요건을 만족한 유저 없음")
+            return
+        }
 
         var count = 0
         for (suspendedUser in suspendedUsers) {

--- a/backend/src/main/java/com/bookbook/domain/suspend/service/SuspendedUserService.kt
+++ b/backend/src/main/java/com/bookbook/domain/suspend/service/SuspendedUserService.kt
@@ -9,6 +9,7 @@ import com.bookbook.domain.user.enums.UserStatus
 import com.bookbook.domain.user.service.UserService
 import com.bookbook.global.exception.ServiceException
 import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -47,13 +48,22 @@ class SuspendedUserService(
     /**
      * 정지된 유저 히스토리를 페이지로 가져옵니다.
      *
-     * @param pageable 페이지 정보
+     * @param page 페이지 번호
+     * @param size 한 페이지 당 크기
+     * @param userId 검색하려는 유저 Id
      * @return 유저 정지 히스토리 페이지
      */
     @Transactional(readOnly = true)
-    fun getSuspendedHistoryPage(pageable: Pageable, userId: Long?): Page<UserSuspendResponseDto> {
-        return suspendedUserRepository.findAllFilteredUser(pageable, userId)
-            .map { suspendedUser -> UserSuspendResponseDto(suspendedUser) }
+    fun getSuspendedHistoryPage(
+        page: Int,
+        size: Int,
+        userId: Long? = null
+    ): Page<UserSuspendResponseDto> {
+        val pageable: Pageable = PageRequest.of(page - 1, size)
+
+        return suspendedUserRepository
+            .findAllFilteredUser(pageable, userId)
+            .map { UserSuspendResponseDto(it) }
     }
 
     /**
@@ -87,7 +97,7 @@ class SuspendedUserService(
      */
     private fun checkUserIsActive(user: User) {
         if (user.userStatus == UserStatus.ACTIVE)
-            throw ServiceException("409-1", "해당 유저의 정지가 이미 해제되어 있습니다")
+            throw ServiceException("409-1", "해당 유저의 정지가 이미 해제되어 있습니다.")
     }
 
     /**

--- a/backend/src/main/java/com/bookbook/domain/user/repository/UserRepository.kt
+++ b/backend/src/main/java/com/bookbook/domain/user/repository/UserRepository.kt
@@ -7,12 +7,19 @@ import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
-import java.time.LocalDateTime
 import java.util.*
 
 interface UserRepository : JpaRepository<User, Long> {
     fun findByUsername(username: String): Optional<User>
-    fun findAllByUserStatusAndResumedAtBefore(userStatus: UserStatus, now: LocalDateTime): MutableList<User>
+
+    @Query("""
+        SELECT u FROM User u WHERE 
+        u.userStatus = com.bookbook.domain.user.enums.UserStatus.SUSPENDED AND 
+        u.resumedAt IS NOT NULL AND
+        u.resumedAt <= NOW() ORDER BY 
+        u.resumedAt ASC LIMIT 100
+    """)
+    fun findAllPossibleResumedUsers(): List<User>
 
     @Query(
         """

--- a/backend/src/main/java/com/bookbook/global/util/EnvLoader.kt
+++ b/backend/src/main/java/com/bookbook/global/util/EnvLoader.kt
@@ -1,0 +1,13 @@
+package com.bookbook.global.util
+
+import io.github.cdimascio.dotenv.Dotenv
+
+object EnvLoader {
+
+    fun loadEnv() {
+        Dotenv.configure()
+            .ignoreIfMissing()
+            .systemProperties() // 이 한 줄로 기존의 forEach 루프를 대체합니다.
+            .load()
+    }
+}

--- a/backend/src/test/java/com/bookbook/BookbookApplicationTests.java
+++ b/backend/src/test/java/com/bookbook/BookbookApplicationTests.java
@@ -1,8 +1,0 @@
-package com.bookbook;
-
-import org.springframework.boot.test.context.SpringBootTest;
-
-@SpringBootTest
-class BookbookApplicationTests {
-
-}

--- a/backend/src/test/java/com/bookbook/TestSetup.kt
+++ b/backend/src/test/java/com/bookbook/TestSetup.kt
@@ -4,7 +4,10 @@ import com.bookbook.domain.suspend.entity.SuspendedUser
 import com.bookbook.domain.suspend.repository.SuspendedUserRepository
 import com.bookbook.domain.user.entity.User
 import com.bookbook.domain.user.repository.UserRepository
+import com.bookbook.global.util.EnvLoader
 import jakarta.annotation.PostConstruct
+import org.springframework.core.Ordered
+import org.springframework.core.annotation.Order
 import org.springframework.stereotype.Component
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.transaction.annotation.Transactional
@@ -15,6 +18,12 @@ class UserSetup (
     private val userRepository: UserRepository,
     private val suspendedUserRepository: SuspendedUserRepository
 ){
+
+    @PostConstruct
+    @Order(Ordered.HIGHEST_PRECEDENCE)
+    private fun loadEnv(){
+        EnvLoader.loadEnv()
+    }
 
     @Transactional
     @PostConstruct

--- a/backend/src/test/java/com/bookbook/TestSetup.kt
+++ b/backend/src/test/java/com/bookbook/TestSetup.kt
@@ -14,7 +14,7 @@ import org.springframework.transaction.annotation.Transactional
 
 @Component
 @ActiveProfiles("test")
-class UserSetup (
+class TestSetup (
     private val userRepository: UserRepository,
     private val suspendedUserRepository: SuspendedUserRepository
 ){
@@ -43,7 +43,7 @@ class UserSetup (
     }
 
     @Transactional
-    fun setSuspendedUser() {
+    fun setSuspendedUsers() {
         val users = userRepository.findAll()
         val period = 7
 

--- a/backend/src/test/java/com/bookbook/UserSetup.kt
+++ b/backend/src/test/java/com/bookbook/UserSetup.kt
@@ -1,0 +1,52 @@
+package com.bookbook
+
+import com.bookbook.domain.suspend.entity.SuspendedUser
+import com.bookbook.domain.suspend.repository.SuspendedUserRepository
+import com.bookbook.domain.user.entity.User
+import com.bookbook.domain.user.repository.UserRepository
+import jakarta.annotation.PostConstruct
+import org.springframework.stereotype.Component
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+@ActiveProfiles("test")
+class UserSetup (
+    private val userRepository: UserRepository,
+    private val suspendedUserRepository: SuspendedUserRepository
+){
+
+    @Transactional
+    @PostConstruct
+    fun createDummyUser() {
+        for (i in 1..5) {
+            val user = User(
+                username = "user$i",
+                password = "password-$i",
+                nickname = "nickname-$i",
+                email = "email_$i@test.com",
+                address = "서울시",
+                registrationCompleted = true
+            )
+
+            userRepository.save(user)
+        }
+    }
+
+    @Transactional
+    fun setSuspendedUser() {
+        val users = userRepository.findAll()
+        val period = 7
+
+        users.filter { !it.isAdmin && it.id > 3 }.forEach {
+            it.suspend(period)
+
+            val suspendedUser = SuspendedUser(
+                user = it,
+                reason = "그냥 유저 ${it.username}을 ${period}일 동안 정지함",
+            )
+
+            suspendedUserRepository.save(suspendedUser)
+        }
+    }
+}

--- a/backend/src/test/java/com/bookbook/domain/suspend/controller/SuspendedUserControllerTest.kt
+++ b/backend/src/test/java/com/bookbook/domain/suspend/controller/SuspendedUserControllerTest.kt
@@ -1,0 +1,243 @@
+package com.bookbook.domain.suspend.controller
+
+import com.bookbook.UserSetup
+import com.bookbook.domain.suspend.service.SuspendedUserService
+import com.bookbook.domain.user.service.UserService
+import org.hamcrest.Matchers
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.MediaType
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.TestPropertySource
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers.print
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
+import org.springframework.transaction.annotation.Transactional
+
+@ActiveProfiles("test")
+@TestPropertySource(properties = [
+    "ALADIN_API_KEY=test-key" // test 프로파일에서 이와 관련한 오류 발생으로 인해 임의로 추가
+])
+@SpringBootTest
+@Transactional
+@AutoConfigureMockMvc
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@WithMockUser(roles = ["ADMIN"])
+class SuspendedUserControllerTest {
+
+    @Autowired
+    private lateinit var mvc: MockMvc
+
+    @Autowired
+    private lateinit var suspendedUserService: SuspendedUserService
+
+    @Autowired
+    private lateinit var userService: UserService
+
+    @Autowired
+    private lateinit var userSetup: UserSetup
+
+    @BeforeAll
+    fun setUp() {
+        userSetup.setSuspendedUser()
+    }
+
+    @Test
+    @DisplayName("유저 정지")
+    fun t1() {
+        val userId = 2
+        val period = 7
+
+        val suspendAction = mvc
+            .perform(
+                patch("/api/v1/admin/users/suspend")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+                        {
+                            "userId": $userId,
+                            "reason" : "광고",
+                            "period" : $period
+                        }
+                    """
+                )
+            )
+            .andDo(print())
+
+        val user = userService.findById(userId.toLong())
+            ?: throw NoSuchElementException("존재하지 않는 유저입니다.")
+
+        suspendAction
+            .andExpect(handler().handlerType(SuspendedUserController::class.java))
+            .andExpect(handler().methodName("suspendUser"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.resultCode").value("200-1"))
+            .andExpect(jsonPath("$.msg").value("user${userId}님을 정지하였습니다."))
+            .andExpect(jsonPath("$.data").exists())
+            .andExpect(jsonPath("$.data.userStatus").value("SUSPENDED"))
+            .andExpect(jsonPath("$.data.suspendedAt").value(Matchers.startsWith(user.suspendedAt.toString().take(20))))
+            .andExpect(jsonPath("$.data.resumedAt").value(Matchers.startsWith(user.resumedAt.toString().take(20))))
+    }
+    @Test
+    @DisplayName("정지된 유저 목록 조회")
+    fun t2() {
+        val page = 1
+        val size = 10
+
+        val resultAction = mvc
+            .perform(
+                get("/api/v1/admin/users/suspend")
+            )
+            .andDo(print())
+
+        val suspendedUsers = suspendedUserService.getSuspendedHistoryPage(page, size).content
+
+        for (i in suspendedUsers.indices) {
+            val user = suspendedUsers[i]
+
+            resultAction
+                .andExpect(jsonPath("$.data.content[$i].userId").value(user.userId))
+                .andExpect(jsonPath("$.data.content[$i].name").value(user.name))
+                .andExpect(jsonPath("$.data.content[$i].reason").value(user.reason))
+                .andExpect(jsonPath("$.data.content[$i].suspendedAt").value(Matchers.startsWith(user.suspendedAt.toString().take(20))))
+                .andExpect(jsonPath("$.data.content[$i].resumedAt").value(Matchers.startsWith(user.resumedAt.toString().take(20))))
+        }
+    }
+
+    @Test
+    @DisplayName("정지된 유저를 다시 정지")
+    fun t3() {
+        val userId = 4
+        val period = 7
+
+        val suspendAction = mvc
+            .perform(
+                patch("/api/v1/admin/users/suspend")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        """
+                        {
+                            "userId": $userId,
+                            "reason" : "광고",
+                            "period" : $period
+                        }
+                    """
+                    )
+            )
+            .andDo(print())
+
+        suspendAction
+            .andExpect(handler().handlerType(SuspendedUserController::class.java))
+            .andExpect(handler().methodName("suspendUser"))
+            .andExpect(status().isConflict)
+            .andExpect(jsonPath("$.resultCode").value("409-1"))
+            .andExpect(jsonPath("$.msg").value("이 유저는 이미 정지 중입니다."))
+            .andExpect(jsonPath("$.data").doesNotExist())
+    }
+
+    @Test
+    @DisplayName("정지된 멤버를 해제")
+    fun t4() {
+        val userId = 4
+
+        val suspendAction = mvc
+            .perform(
+                patch("/api/v1/admin/users/$userId/resume")
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andDo(print())
+
+        suspendAction
+            .andExpect(handler().handlerType(SuspendedUserController::class.java))
+            .andExpect(handler().methodName("resumeUser"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.resultCode").value("200-1"))
+            .andExpect(jsonPath("$.msg").value("user${userId}님의 정지가 해제되었습니다."))
+            .andExpect(jsonPath("$.data").exists())
+            .andExpect(jsonPath("$.data.userStatus").value("ACTIVE"))
+            .andExpect(jsonPath("$.data.resumedAt").doesNotExist())
+            .andExpect(jsonPath("$.data.suspendedAt").doesNotExist())
+    }
+
+    @Test
+    @DisplayName("정지가 해제된 유저를 다시 해제 시도")
+    fun t5() {
+        val userId = 2
+
+        val suspendAction = mvc
+            .perform(
+                patch("/api/v1/admin/users/$userId/resume")
+                    .contentType(MediaType.APPLICATION_JSON)
+            )
+            .andDo(print())
+
+        suspendAction
+            .andExpect(handler().handlerType(SuspendedUserController::class.java))
+            .andExpect(handler().methodName("resumeUser"))
+            .andExpect(status().isConflict)
+            .andExpect(jsonPath("$.resultCode").value("409-1"))
+            .andExpect(jsonPath("$.msg").value("해당 유저의 정지가 이미 해제되어 있습니다."))
+            .andExpect(jsonPath("$.data").doesNotExist())
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 요청 1")
+    fun t6() {
+        val userId = 2
+
+        val suspendAction = mvc
+            .perform(
+                patch("/api/v1/admin/users/suspend")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        """
+                        {
+                            "userId": $userId,
+                            "period": 7
+                        }
+                    """
+                    )
+            )
+            .andDo(print())
+
+        suspendAction
+            .andExpect(handler().handlerType(SuspendedUserController::class.java))
+            .andExpect(handler().methodName("suspendUser"))
+            .andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.resultCode").value("400-1"))
+            .andExpect(jsonPath("$.data").doesNotExist())
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 요청 2")
+    fun t7() {
+        val suspendAction = mvc
+            .perform(
+                patch("/api/v1/admin/users/suspend")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        """
+                        {
+                            "reason" : "테스트"
+                        }
+                    """
+                    )
+            )
+            .andDo(print())
+
+        suspendAction
+            .andExpect(handler().handlerType(SuspendedUserController::class.java))
+            .andExpect(handler().methodName("suspendUser"))
+            .andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.resultCode").value("400-1"))
+            .andExpect(jsonPath("$.data").doesNotExist())
+    }
+}

--- a/backend/src/test/java/com/bookbook/domain/suspend/controller/SuspendedUserControllerTest.kt
+++ b/backend/src/test/java/com/bookbook/domain/suspend/controller/SuspendedUserControllerTest.kt
@@ -14,7 +14,6 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.MediaType
 import org.springframework.security.test.context.support.WithMockUser
 import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.context.TestPropertySource
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch

--- a/backend/src/test/java/com/bookbook/domain/suspend/controller/SuspendedUserControllerTest.kt
+++ b/backend/src/test/java/com/bookbook/domain/suspend/controller/SuspendedUserControllerTest.kt
@@ -1,6 +1,6 @@
 package com.bookbook.domain.suspend.controller
 
-import com.bookbook.UserSetup
+import com.bookbook.TestSetup
 import com.bookbook.domain.suspend.service.SuspendedUserService
 import com.bookbook.domain.user.service.UserService
 import org.hamcrest.Matchers
@@ -22,9 +22,6 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
 import org.springframework.transaction.annotation.Transactional
 
 @ActiveProfiles("test")
-@TestPropertySource(properties = [
-    "ALADIN_API_KEY=test-key" // test 프로파일에서 이와 관련한 오류 발생으로 인해 임의로 추가
-])
 @SpringBootTest
 @Transactional
 @AutoConfigureMockMvc
@@ -42,11 +39,11 @@ class SuspendedUserControllerTest {
     private lateinit var userService: UserService
 
     @Autowired
-    private lateinit var userSetup: UserSetup
+    private lateinit var setup: TestSetup
 
     @BeforeAll
     fun setUp() {
-        userSetup.setSuspendedUser()
+        setup.setSuspendedUsers()
     }
 
     @Test


### PR DESCRIPTION
## 💡 변경 사항
- [x] 회원 정지 테스트 추가
- [x] DTO 수정
  * 응답 DTO 타입 수정
  * 요청 DTO 유효성 검사 강화
- [x] 스케줄러 수정
  * 15분마다 확인하는 대신, 최대 해제 유저수를 100명으로 제한합니다.
- [x] EnvLoader 유틸 클래스 추가
  * 테스트 케이스에서는 main을 통한 env 파일 로딩이 진행되지 않는 것 같습니다. 그래서 테스트 케이스에서도 별도로 로딩을 해주어야 하는데요. `@Configuration`을 통해 이 부분이 어느 프로파일이든 자동으로 실행될 수 있도록 고민할 생각입니다.

---
### ✅ 특이 사항
#### - `TestSetup` 클래스
  * 테스트용 더미 데이터를 만들기 위해 임의로 만든 클래스 입니다. 필요에 맞게 이름 변경하셔도 됩니다.
  * Test 프로파일 전용이므로 파일 DB에 입력되지 않습니다.

#### - `SuspendedUserControllerTest` 클래스
  * `@WithMockUser` - 시큐리티와 연동되는 테스트의 경우 정상적으로 진행되지 않는 경우가 있습니다. 그래서 시큐리티가 연동되어도 테스트를 진행할 수 있는 방법이 여러 개 있는데요. 저는 DefaultOAuth2User 유저와 관련해 이름, 역할 등으로 유효한 값을 넣어 진행할 수 있었습니다. (메소드, 클래스에 붙이면 작동)
  * `@TestInstance` - 테스트를 진행할 때 클래스의 라이프사이클을 어떻게 설정할 것이냐에 대한 부분인데, 제가 설정한 건 `@BeforeAll` 메소드를 사용하기 위해 `Lifecycle.PER_CLASS`를 적용했습니다.

#### - 요청 엔티티 DTO 유효성 검사 강화
  * 필요한 필드가 빠지거나 어느 정도의 유효성 검사를 설정했더라도, 일부 케이스는 기본값이 자동으로 들어가서 이 설정을 회피할 수 있다고 합니다.
  * 실제로 `SuspendedUserControllerTest` 의 t6, t7 메소드는 고의로 값을 누락했는데도 테스트를 통과하는 경우가 있었습니다.
  * 테스트 작성 때 참고해주시면 감사드리겠습니다.

---
### 🔗 관련 이슈
#96 
