### PR TITLE
Test: 유저 도메인 - 어드민 파트 테스트 케이스 추가 (#109)

### DIFF
--- a/backend/src/main/java/com/bookbook/domain/user/controller/AdminController.kt
+++ b/backend/src/main/java/com/bookbook/domain/user/controller/AdminController.kt
@@ -6,6 +6,7 @@ import com.bookbook.domain.user.dto.response.UserLoginResponseDto
 import com.bookbook.domain.user.dto.response.UserSimpleResponseDto
 import com.bookbook.domain.user.enums.UserStatus
 import com.bookbook.domain.user.service.AdminService
+import com.bookbook.global.exception.ServiceException
 import com.bookbook.global.jpa.dto.response.PageResponseDto
 import com.bookbook.global.rsdata.RsData
 import com.bookbook.global.security.CustomOAuth2User
@@ -141,9 +142,12 @@ class AdminController (
         @RequestParam(required = false) status: List<UserStatus>?,
         @RequestParam(required = false) userId: Long?
     ): ResponseEntity<RsData<PageResponseDto<UserSimpleResponseDto>>> {
+        if (page < 1) throw ServiceException("페이지 번호는 1보다 작을 수 없습니다")
+        if (size < 1) throw ServiceException("페이지 당 크기는 1보다 작을 수 없습니다")
+
         val pageable: Pageable = PageRequest.of(page - 1, size)
 
-        val userPage= adminService.getFilteredUsers(pageable, status, userId)
+        val userPage = adminService.getFilteredUsers(pageable, status, userId)
         val response = PageResponseDto(userPage)
 
         return ResponseEntity.ok(

--- a/backend/src/main/java/com/bookbook/domain/user/controller/AdminController.kt
+++ b/backend/src/main/java/com/bookbook/domain/user/controller/AdminController.kt
@@ -142,8 +142,8 @@ class AdminController (
         @RequestParam(required = false) status: List<UserStatus>?,
         @RequestParam(required = false) userId: Long?
     ): ResponseEntity<RsData<PageResponseDto<UserSimpleResponseDto>>> {
-        if (page < 1) throw ServiceException("페이지 번호는 1보다 작을 수 없습니다")
-        if (size < 1) throw ServiceException("페이지 당 크기는 1보다 작을 수 없습니다")
+        if (page < 1) throw ServiceException("페이지 번호는 1보다 작을 수 없습니다.")
+        if (size < 1) throw ServiceException("페이지 당 크기는 1보다 작을 수 없습니다.")
 
         val pageable: Pageable = PageRequest.of(page - 1, size)
 

--- a/backend/src/main/java/com/bookbook/domain/user/controller/AdminController.kt
+++ b/backend/src/main/java/com/bookbook/domain/user/controller/AdminController.kt
@@ -6,7 +6,6 @@ import com.bookbook.domain.user.dto.response.UserLoginResponseDto
 import com.bookbook.domain.user.dto.response.UserSimpleResponseDto
 import com.bookbook.domain.user.enums.UserStatus
 import com.bookbook.domain.user.service.AdminService
-import com.bookbook.global.exception.ServiceException
 import com.bookbook.global.jpa.dto.response.PageResponseDto
 import com.bookbook.global.rsdata.RsData
 import com.bookbook.global.security.CustomOAuth2User
@@ -48,7 +47,7 @@ class AdminController (
     @PostMapping("/login")
     @Operation(summary = "어드민 로그인")
     fun adminLogin(
-        @RequestBody requestDto: @Valid UserLoginRequestDto,
+        @RequestBody @Valid requestDto: UserLoginRequestDto,
         response: HttpServletResponse
     ): ResponseEntity<RsData<UserLoginResponseDto>> {
         val admin = adminService.login(requestDto.username, requestDto.password)
@@ -91,7 +90,7 @@ class AdminController (
         invalidateCookie(response, jwtRefreshTokenCookieName)
 
         currentUser?.let {
-            jwtProvider.deleteRefreshToken(currentUser.userId)
+            jwtProvider.deleteRefreshToken(it.userId)
         }
 
         return ResponseEntity.ok(
@@ -142,8 +141,8 @@ class AdminController (
         @RequestParam(required = false) status: List<UserStatus>?,
         @RequestParam(required = false) userId: Long?
     ): ResponseEntity<RsData<PageResponseDto<UserSimpleResponseDto>>> {
-        if (page < 1) throw ServiceException("페이지 번호는 1보다 작을 수 없습니다.")
-        if (size < 1) throw ServiceException("페이지 당 크기는 1보다 작을 수 없습니다.")
+        val page = if (page < 1) 1 else page
+        val size = if (size < 1) 10 else size
 
         val pageable: Pageable = PageRequest.of(page - 1, size)
 

--- a/backend/src/main/java/com/bookbook/domain/user/controller/AdminController.kt
+++ b/backend/src/main/java/com/bookbook/domain/user/controller/AdminController.kt
@@ -138,7 +138,7 @@ class AdminController (
     fun getFilteredUsers(
         @RequestParam(defaultValue = "1") page: Int,
         @RequestParam(defaultValue = "10") size: Int,
-        @RequestParam(required = false) status: MutableList<UserStatus>?,
+        @RequestParam(required = false) status: List<UserStatus>?,
         @RequestParam(required = false) userId: Long?
     ): ResponseEntity<RsData<PageResponseDto<UserSimpleResponseDto>>> {
         val pageable: Pageable = PageRequest.of(page - 1, size)

--- a/backend/src/main/java/com/bookbook/domain/user/repository/UserRepository.kt
+++ b/backend/src/main/java/com/bookbook/domain/user/repository/UserRepository.kt
@@ -31,7 +31,7 @@ interface UserRepository : JpaRepository<User, Long> {
     )
     fun findFilteredUsers(
         pageable: Pageable?,
-        @Param("status") status: MutableList<UserStatus>?,
+        @Param("status") status: List<UserStatus>?,
         @Param("userId") userId: Long?
     ): Page<User>
 

--- a/backend/src/main/java/com/bookbook/domain/user/service/AdminService.kt
+++ b/backend/src/main/java/com/bookbook/domain/user/service/AdminService.kt
@@ -1,7 +1,7 @@
 package com.bookbook.domain.user.service
 
-import com.bookbook.domain.user.dto.response.UserSimpleResponseDto
 import com.bookbook.domain.user.dto.response.UserDetailResponseDto
+import com.bookbook.domain.user.dto.response.UserSimpleResponseDto
 import com.bookbook.domain.user.entity.User
 import com.bookbook.domain.user.enums.UserStatus
 import com.bookbook.domain.user.repository.UserRepository

--- a/backend/src/main/java/com/bookbook/domain/user/service/AdminService.kt
+++ b/backend/src/main/java/com/bookbook/domain/user/service/AdminService.kt
@@ -53,7 +53,7 @@ class AdminService(
      */
     @Transactional(readOnly = true)
     fun getFilteredUsers(
-        pageable: Pageable, status: MutableList<UserStatus>?, userId: Long?
+        pageable: Pageable, status: List<UserStatus>?, userId: Long?
     ): Page<UserSimpleResponseDto> {
         return userRepository.findFilteredUsers(pageable, status, userId)
             .map { UserSimpleResponseDto(it) }

--- a/backend/src/test/java/com/bookbook/TestSetup.kt
+++ b/backend/src/test/java/com/bookbook/TestSetup.kt
@@ -3,6 +3,7 @@ package com.bookbook
 import com.bookbook.domain.suspend.entity.SuspendedUser
 import com.bookbook.domain.suspend.repository.SuspendedUserRepository
 import com.bookbook.domain.user.entity.User
+import com.bookbook.domain.user.enums.Role
 import com.bookbook.domain.user.repository.UserRepository
 import com.bookbook.global.security.CustomOAuth2User
 import jakarta.annotation.PostConstruct
@@ -12,7 +13,6 @@ import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Component
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.transaction.annotation.Transactional
-import com.bookbook.domain.user.enums.Role
 
 
 @Component
@@ -53,6 +53,8 @@ class TestSetup (
         )
 
         userRepository.save(admin)
+
+        setSuspendedUsers()
     }
 
     @Transactional
@@ -68,6 +70,8 @@ class TestSetup (
                 reason = "그냥 유저 ${it.username}을 ${period}일 동안 정지함",
             )
 
+            // 더티체킹이 제대로 활성화되지 않아 명시적으로 저장
+            userRepository.save(it)
             suspendedUserRepository.save(suspendedUser)
         }
     }

--- a/backend/src/test/java/com/bookbook/domain/user/controller/AdminControllerTest.kt
+++ b/backend/src/test/java/com/bookbook/domain/user/controller/AdminControllerTest.kt
@@ -371,6 +371,52 @@ class AdminControllerTest {
         iterateFromList(resultActions, users)
     }
 
+    @Test
+    @DisplayName("유저 목록 조회 - 잘못된 page 인수")
+    fun t10() {
+        val page = -1
+        val size = 10
+
+        val resultAction = mvc
+            .perform(
+                get("/api/v1/admin/users")
+                    .param("page", page.toString())
+                    .param("size", size.toString())
+            )
+            .andDo(print())
+
+        resultAction
+            .andExpect(handler().handlerType(AdminController::class.java))
+            .andExpect(handler().methodName("getFilteredUsers"))
+            .andExpect(jsonPath("$.resultCode").value("400"))
+            .andExpect(jsonPath("$.msg").value("페이지 번호는 1보다 작을 수 없습니다."))
+            .andExpect(jsonPath("$.data").doesNotExist())
+
+    }
+
+    @Test
+    @DisplayName("유저 목록 조회 - 잘못된 size 인수")
+    fun t11() {
+        val page = 1
+        val size = -1
+
+        val resultAction = mvc
+            .perform(
+                get("/api/v1/admin/users")
+                    .param("page", page.toString())
+                    .param("size", size.toString())
+            )
+            .andDo(print())
+
+        resultAction
+            .andExpect(handler().handlerType(AdminController::class.java))
+            .andExpect(handler().methodName("getFilteredUsers"))
+            .andExpect(jsonPath("$.resultCode").value("400"))
+            .andExpect(jsonPath("$.msg").value("페이지 당 크기는 1보다 작을 수 없습니다."))
+            .andExpect(jsonPath("$.data").doesNotExist())
+
+    }
+
     private fun iterateFromList(resultActions: ResultActions, users: List<UserSimpleResponseDto>) {
         for (i in users.indices) {
             val user = users[i]

--- a/backend/src/test/java/com/bookbook/domain/user/controller/AdminControllerTest.kt
+++ b/backend/src/test/java/com/bookbook/domain/user/controller/AdminControllerTest.kt
@@ -32,6 +32,7 @@ import org.springframework.transaction.annotation.Transactional
 @AutoConfigureMockMvc
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @WithMockUser(roles = ["ADMIN"])
+@DisplayName("AdminController 통합 테스트")
 class AdminControllerTest {
 
     @Autowired

--- a/backend/src/test/java/com/bookbook/domain/user/controller/AdminControllerTest.kt
+++ b/backend/src/test/java/com/bookbook/domain/user/controller/AdminControllerTest.kt
@@ -1,0 +1,392 @@
+package com.bookbook.domain.user.controller
+
+import com.bookbook.TestSetup
+import com.bookbook.domain.user.dto.response.UserSimpleResponseDto
+import com.bookbook.domain.user.enums.UserStatus
+import com.bookbook.domain.user.service.AdminService
+import com.bookbook.domain.user.service.UserService
+import com.bookbook.global.security.CustomOAuth2User
+import org.assertj.core.api.Assertions.assertThat
+import org.hamcrest.Matchers
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.data.domain.PageRequest
+import org.springframework.http.MediaType
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.ResultActions
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers.print
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
+import org.springframework.transaction.annotation.Transactional
+
+@ActiveProfiles("test")
+@SpringBootTest
+@Transactional
+@AutoConfigureMockMvc
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@WithMockUser(roles = ["ADMIN"])
+class AdminControllerTest {
+
+    @Autowired
+    private lateinit var mvc: MockMvc
+
+    @Autowired
+    private lateinit var adminService: AdminService
+
+    @Autowired
+    private lateinit var userService: UserService
+
+    @Autowired
+    private lateinit var testSetup: TestSetup
+
+    private lateinit var mockUser: CustomOAuth2User
+
+    @BeforeAll
+    fun before() {
+        mockUser = testSetup.createCustomOAuth2User(
+            userService.findById(2L)!! // USER 권한 유저
+        )
+    }
+
+    @Test
+    @DisplayName("로그인")
+    fun t1() {
+        val username = "admin-test"
+        val password = "admin-test-pass"
+        val nickname = "admin-test-nick"
+
+        val resultActions = mvc
+            .perform(
+                post("/api/v1/admin/login")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        """
+                        {
+                            "username": "$username",
+                            "password": "$password"
+                        }
+                        """
+                    )
+            )
+            .andDo(print())
+
+        resultActions
+            .andExpect(handler().handlerType(AdminController::class.java))
+            .andExpect(handler().methodName("adminLogin"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.resultCode").value("200-1"))
+            .andExpect(jsonPath("$.msg").value("관리자 ${username}님이 로그인하였습니다."))
+            .andExpect(jsonPath("$.data").exists())
+            .andExpect(jsonPath("$.data.username").value(username))
+            .andExpect(jsonPath("$.data.nickname").value(nickname))
+            .andExpect(jsonPath("$.data.role").value("ADMIN"))
+            .andExpect { result ->
+                val accessToken = result.response.getCookie("JWT_TOKEN") ?: throw NoSuchElementException()
+                val refreshToken = result.response.getCookie("refreshToken") ?: throw NoSuchElementException()
+
+                assertThat(accessToken.value).isNotBlank
+                assertThat(accessToken.path).isEqualTo("/")
+                assertThat(accessToken.isHttpOnly).isTrue
+
+                assertThat(refreshToken.value).isNotBlank
+                assertThat(refreshToken.path).isEqualTo("/")
+                assertThat(refreshToken.isHttpOnly).isTrue
+            }
+    }
+
+    @Test
+    @DisplayName("유저가 로그인 시도")
+    fun t2() {
+        val username = "user1"
+        val password = "password-1"
+
+        val resultActions = mvc
+            .perform(
+                post("/api/v1/admin/login")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(
+                        """
+                        {
+                            "username": "$username",
+                            "password": "$password"
+                        }
+                        """
+                    )
+            )
+            .andDo(print())
+
+        resultActions
+            .andExpect(handler().handlerType(AdminController::class.java))
+            .andExpect(handler().methodName("adminLogin"))
+            .andExpect(status().isUnauthorized)
+            .andExpect(jsonPath("$.resultCode").value("401-UNAUTHORIZED"))
+            .andExpect(jsonPath("$.msg").value("허가되지 않은 접근입니다."))
+            .andExpect(jsonPath("$.data").doesNotExist())
+    }
+
+    @Test
+    @DisplayName("로그아웃")
+    fun t3() {
+        val resultActions = mvc
+            .perform(
+                delete("/api/v1/admin/logout")
+            )
+            .andDo(print())
+
+        resultActions
+            .andExpect(handler().handlerType(AdminController::class.java))
+            .andExpect(handler().methodName("adminLogout"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.resultCode").value("200-1"))
+            .andExpect(jsonPath("$.msg").value("로그아웃을 정상적으로 완료했습니다."))
+            .andExpect(jsonPath("$.data").doesNotExist())
+            .andExpect { result ->
+                val accessToken = result.response.getCookie("JWT_TOKEN") ?: throw NoSuchElementException()
+                assertThat(accessToken.value).isNullOrEmpty()
+                assertThat(accessToken.maxAge).isEqualTo(0)
+                assertThat(accessToken.path).isEqualTo("/")
+                assertThat(accessToken.isHttpOnly).isTrue
+
+                val refreshToken = result.response.getCookie("refreshToken") ?: throw NoSuchElementException()
+                assertThat(refreshToken.value).isNullOrEmpty()
+                assertThat(refreshToken.maxAge).isEqualTo(0)
+                assertThat(refreshToken.path).isEqualTo("/")
+                assertThat(refreshToken.isHttpOnly).isTrue
+            }
+    }
+
+    @Test
+    @DisplayName("유저 세부 정보 가져오기")
+    fun t4() {
+        val userId = 4L
+
+        val resultActions = mvc
+            .perform(
+                get("/api/v1/admin/users/$userId")
+            )
+            .andDo(print())
+
+        val user = userService.findById(userId) ?: throw NoSuchElementException()
+
+        resultActions
+            .andExpect(handler().handlerType(AdminController::class.java))
+            .andExpect(handler().methodName("getUserDetail"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.resultCode").value("200-1"))
+            .andExpect(jsonPath("$.msg").value("유저 \"${user.nickname}\"님의 정보를 찾았습니다."))
+            .andExpect(jsonPath("$.data").exists())
+            .andExpect(jsonPath("$.data.id").value(user.id))
+            .andExpect(jsonPath("$.data.username").value(user.username))
+            .andExpect(jsonPath("$.data.nickname").value(user.nickname))
+            .andExpect(jsonPath("$.data.rating").value(user.rating))
+            .andExpect(
+                jsonPath("$.data.createdAt")
+                    .value(Matchers.startsWith(user.createdDate.toString().take(20)))
+            )
+            .andExpect(
+                jsonPath("$.data.updatedAt")
+                    .value(Matchers.startsWith(user.modifiedDate.toString().take(20)))
+            )
+    }
+
+    @Test
+    @DisplayName("유저 목록 가져오기 without filters")
+    fun t5() {
+        val page = 0
+        val size = 10
+
+        val resultActions = mvc
+            .perform(
+                get("/api/v1/admin/users")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {
+                      "page" : $page,
+                      "size" : $size
+                    }
+                  """
+                )
+
+            )
+            .andDo(print())
+
+        val pageable = PageRequest.of(0, 10)
+
+        val pagedUsers = adminService.getFilteredUsers(pageable, null, null)
+        val users = pagedUsers.content
+
+        resultActions
+            .andExpect(handler().handlerType(AdminController::class.java))
+            .andExpect(handler().methodName("getFilteredUsers"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.resultCode").value("200-1"))
+            .andExpect(jsonPath("$.msg").value("해당 조건에 맞는 ${pagedUsers.totalElements}명의 유저를 찾았습니다."))
+            .andExpect(jsonPath("$.data").exists())
+
+        iterateFromList(resultActions, users)
+    }
+
+    @Test
+    @DisplayName("유저 목록 가져오기 with SUSPENDED status")
+    fun t6() {
+        val page = 1
+        val size = 10
+        val statuses = listOf(UserStatus.SUSPENDED)
+
+        val resultActions = mvc
+            .perform(
+                get("/api/v1/admin/users")
+                .param("page", page.toString())
+                .param("size", size.toString())
+                .apply {
+                    statuses.forEach { status ->
+                        param("status", status.toString())
+                    }
+                }
+            )
+            .andDo(print())
+
+        val pageable = PageRequest.of(page - 1, size)
+
+        val pagedUsers = adminService.getFilteredUsers(pageable, statuses, null)
+        val users = pagedUsers.content
+
+        resultActions
+            .andExpect(handler().handlerType(AdminController::class.java))
+            .andExpect(handler().methodName("getFilteredUsers"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.resultCode").value("200-1"))
+            .andExpect(jsonPath("$.msg").value("해당 조건에 맞는 2명의 유저를 찾았습니다."))
+            .andExpect(jsonPath("$.data").exists())
+
+        iterateFromList(resultActions, users)
+    }
+
+    @Test
+    @DisplayName("유저 목록 가져오기 with SUSPENDED, INACTIVE status")
+    fun t7() {
+        val page = 1
+        val size = 10
+        val statuses = listOf(UserStatus.SUSPENDED, UserStatus.INACTIVE)
+
+        val resultActions = mvc
+            .perform(
+                get("/api/v1/admin/users")
+                .param("page", page.toString())
+                .param("size", size.toString())
+                .apply {
+                    statuses.forEach { status ->
+                        param("status", status.toString())
+                    }
+                }
+            )
+            .andDo(print())
+
+        val pageable = PageRequest.of(page - 1, size)
+
+        val pagedUsers = adminService.getFilteredUsers(pageable, statuses, null)
+        val users = pagedUsers.content
+
+        resultActions
+            .andExpect(handler().handlerType(AdminController::class.java))
+            .andExpect(handler().methodName("getFilteredUsers"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.resultCode").value("200-1"))
+            .andExpect(jsonPath("$.msg").value("해당 조건에 맞는 2명의 유저를 찾았습니다."))
+            .andExpect(jsonPath("$.data").exists())
+
+        iterateFromList(resultActions, users)
+    }
+
+    @Test
+    @DisplayName("유저 목록 가져오기 with single userId")
+    fun t8() {
+        val page = 1
+        val size = 10
+        val userId = 5L
+
+        val resultActions = mvc
+            .perform(
+                get("/api/v1/admin/users")
+                    .param("page", page.toString())
+                    .param("size", size.toString())
+                    .param("userId", userId.toString())
+            )
+            .andDo(print())
+
+        val pageable = PageRequest.of(page - 1, size)
+
+        val pagedUsers = adminService.getFilteredUsers(pageable, null, userId)
+        val users = pagedUsers.content
+
+        resultActions
+            .andExpect(handler().handlerType(AdminController::class.java))
+            .andExpect(handler().methodName("getFilteredUsers"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.resultCode").value("200-1"))
+            .andExpect(jsonPath("$.msg").value("해당 조건에 맞는 1명의 유저를 찾았습니다."))
+            .andExpect(jsonPath("$.data").exists())
+
+        iterateFromList(resultActions, users)
+    }
+
+    @Test
+    @DisplayName("유저 목록 가져오기 with lower size")
+    fun t9() {
+        val page = 1
+        val size = 5
+
+        val resultActions = mvc
+            .perform(
+                get("/api/v1/admin/users")
+                    .param("page", page.toString())
+                    .param("size", size.toString())
+            )
+            .andDo(print())
+
+        val pageable = PageRequest.of(page - 1, size)
+
+        val pagedUsers = adminService.getFilteredUsers(pageable, null, null)
+        val users = pagedUsers.content
+
+        resultActions
+            .andExpect(handler().handlerType(AdminController::class.java))
+            .andExpect(handler().methodName("getFilteredUsers"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.resultCode").value("200-1"))
+            .andExpect(jsonPath("$.msg").value("해당 조건에 맞는 7명의 유저를 찾았습니다."))
+            .andExpect(jsonPath("$.data").exists())
+            .andExpect(jsonPath("$.data.pageInfo").exists())
+            .andExpect(jsonPath("$.data.pageInfo.currentPageElements").value(users.size))
+
+        assertThat(users.size).isEqualTo(size)
+
+        iterateFromList(resultActions, users)
+    }
+
+    private fun iterateFromList(resultActions: ResultActions, users: List<UserSimpleResponseDto>) {
+        for (i in users.indices) {
+            val user = users[i]
+
+            resultActions
+                .andExpect(jsonPath("$.data.content[$i].id").value(user.id))
+                .andExpect(
+                    jsonPath("$.data.content[$i].createdAt")
+                        .value(Matchers.startsWith(user.createdAt.toString().take(20)))
+                )
+                .andExpect(
+                    jsonPath("$.data.content[$i].updatedAt")
+                        .value(Matchers.startsWith(user.updatedAt.toString().take(20)))
+                )
+                .andExpect(jsonPath("$.data.content[$i].nickname").value(user.nickname))
+                .andExpect(jsonPath("$.data.content[$i].username").value(user.username))
+        }
+    }
+}

--- a/backend/src/test/java/com/bookbook/domain/user/controller/AdminControllerTest.kt
+++ b/backend/src/test/java/com/bookbook/domain/user/controller/AdminControllerTest.kt
@@ -200,7 +200,7 @@ class AdminControllerTest {
     @Test
     @DisplayName("유저 목록 가져오기 without filters")
     fun t5() {
-        val page = 0
+        val page = 1
         val size = 10
 
         val resultActions = mvc
@@ -218,7 +218,7 @@ class AdminControllerTest {
             )
             .andDo(print())
 
-        val pageable = PageRequest.of(0, 10)
+        val pageable = PageRequest.of(page - 1, size)
 
         val pagedUsers = adminService.getFilteredUsers(pageable, null, null)
         val users = pagedUsers.content
@@ -389,9 +389,9 @@ class AdminControllerTest {
         resultAction
             .andExpect(handler().handlerType(AdminController::class.java))
             .andExpect(handler().methodName("getFilteredUsers"))
-            .andExpect(jsonPath("$.resultCode").value("400"))
-            .andExpect(jsonPath("$.msg").value("페이지 번호는 1보다 작을 수 없습니다."))
-            .andExpect(jsonPath("$.data").doesNotExist())
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.resultCode").value("200-1"))
+            .andExpect(jsonPath("$.data").exists())
 
     }
 
@@ -412,9 +412,9 @@ class AdminControllerTest {
         resultAction
             .andExpect(handler().handlerType(AdminController::class.java))
             .andExpect(handler().methodName("getFilteredUsers"))
-            .andExpect(jsonPath("$.resultCode").value("400"))
-            .andExpect(jsonPath("$.msg").value("페이지 당 크기는 1보다 작을 수 없습니다."))
-            .andExpect(jsonPath("$.data").doesNotExist())
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.resultCode").value("200-1"))
+            .andExpect(jsonPath("$.data").exists())
 
     }
 


### PR DESCRIPTION
## 💡 변경 사항
- [x] 테스트 케이스 추가
- [x] TestSetup 수정
  * 최초에 정지된 상태의 유저도 존재할 수 있도록 

---
### ✅ 특이 사항
* 변경 사항에도 적혀있다시피 TestSetup 클래스 내용이 수정되었습니다. 다만, 제가 확인해본 바로는 현재 작성된 시점에서는 모든 테스트 정상 동작합니다.
* 페이징 관련 테스트 중 범위를 벗어난 경우, 부적절한 값을 발견한 것을 확인했습니다. #127 PR 쪽도 그러하기에, 수정이 필요할 것 같습니다.

#### 확인된 응답 예시 (33개의 데이터, 5페이지 검색, 페이지 당 10개)
```json
{
  "resultCode": "200-1",
  "msg": "33개의 글을 발견했습니다.",
  "data": {
    "content": [],
    "pageInfo": {
      "currentPage": 5,
      "totalPages": 4,
      "totalElements": 33,
      "currentPageElements": 0,
      "size": 10
    }
  },
  "isFail": false,
  "success": true,
  "statusCode": 200
}
```

#### 이상적인 응답 예시 (조건 동일)
```json
{
  "resultCode": "400-1",
  "msg": "요청 형식이 잘못되었습니다.",
  "data": null,
  "isFail": true,
  "success": false,
  "statusCode": 400
}
```

---
### 🔗 관련 이슈
closed #61 
closed #109 
