### PR TITLE
Test: 신고 도메인 - 어드민 파트 테스트 케이스 추가 (#129)

### DIFF
--- a/backend/src/main/java/com/bookbook/domain/rent/controller/RentAdminController.kt
+++ b/backend/src/main/java/com/bookbook/domain/rent/controller/RentAdminController.kt
@@ -5,6 +5,7 @@ import com.bookbook.domain.rent.dto.response.RentDetailResponseDto
 import com.bookbook.domain.rent.dto.response.RentSimpleResponseDto
 import com.bookbook.domain.rent.entity.RentStatus
 import com.bookbook.domain.rent.service.RentService
+import com.bookbook.global.exception.ServiceException
 import com.bookbook.global.jpa.dto.response.PageResponseDto
 import com.bookbook.global.rsdata.RsData
 import io.swagger.v3.oas.annotations.Operation
@@ -43,6 +44,9 @@ class RentAdminController(
         @RequestParam(required = false) status: List<RentStatus>?,
         @RequestParam(required = false) userId: Long?
     ): ResponseEntity<RsData<PageResponseDto<RentSimpleResponseDto>>> {
+        if (page < 1) throw ServiceException("페이지 번호는 1보다 작을 수 없습니다.")
+        if (size < 1) throw ServiceException("페이지 당 크기는 1보다 작을 수 없습니다.")
+
         val pageable: Pageable = PageRequest.of(page - 1, size)
 
         val rentHistoryPage = rentService.getRentsPage(pageable, status, userId)

--- a/backend/src/main/java/com/bookbook/domain/report/controller/ReportAdminController.kt
+++ b/backend/src/main/java/com/bookbook/domain/report/controller/ReportAdminController.kt
@@ -4,6 +4,7 @@ import com.bookbook.domain.report.dto.response.ReportDetailResponseDto
 import com.bookbook.domain.report.dto.response.ReportSimpleResponseDto
 import com.bookbook.domain.report.enums.ReportStatus
 import com.bookbook.domain.report.service.ReportService
+import com.bookbook.global.extension.requireAdmin
 import com.bookbook.global.jpa.dto.response.PageResponseDto
 import com.bookbook.global.rsdata.RsData
 import com.bookbook.global.security.CustomOAuth2User
@@ -41,10 +42,11 @@ class ReportAdminController (
     fun getReportPage(
         @RequestParam(defaultValue = "1") page: Int,
         @RequestParam(defaultValue = "10") size: Int,
-        @RequestParam(required = false) status: MutableList<ReportStatus>?,
-        @RequestParam(required = false) targetUserId: Long?
         @RequestParam(required = false) status: List<ReportStatus>?,
+        @RequestParam(required = false) targetUserId: Long?,
+        @AuthenticationPrincipal customOAuth2User: CustomOAuth2User?
     ): ResponseEntity<RsData<PageResponseDto<ReportSimpleResponseDto>>> {
+        customOAuth2User.requireAdmin()
 
         val page = if (page < 1) 1 else page
         val size = if (size < 1) 10 else size
@@ -72,8 +74,11 @@ class ReportAdminController (
     @GetMapping("/{reportId}/review")
     @Operation(summary = "단일 신고 상세 조회")
     fun getReportDetail(
-        @PathVariable reportId: Long
+        @PathVariable reportId: Long,
+        @AuthenticationPrincipal customOAuth2User: CustomOAuth2User?
     ): ResponseEntity<RsData<ReportDetailResponseDto>> {
+        customOAuth2User.requireAdmin()
+
         val reportDetail = reportService.getReportDetail(reportId)
 
         return ResponseEntity.ok(
@@ -94,9 +99,11 @@ class ReportAdminController (
     @Operation(summary = "단일 신고 처리 완료")
     fun processReport(
         @PathVariable reportId: Long,
-        @AuthenticationPrincipal adminUser: CustomOAuth2User
+        @AuthenticationPrincipal customOAuth2User: CustomOAuth2User?
     ): ResponseEntity<RsData<Void>> {
-        reportService.markReportAsProcessed(reportId, adminUser.userId)
+        val customOAuth2User = customOAuth2User.requireAdmin()
+
+        reportService.markReportAsProcessed(reportId, customOAuth2User.userId)
         log.info("{}번 신고 처리 완료", reportId)
 
         return ResponseEntity.ok(

--- a/backend/src/main/java/com/bookbook/domain/report/controller/ReportAdminController.kt
+++ b/backend/src/main/java/com/bookbook/domain/report/controller/ReportAdminController.kt
@@ -43,7 +43,12 @@ class ReportAdminController (
         @RequestParam(defaultValue = "10") size: Int,
         @RequestParam(required = false) status: MutableList<ReportStatus>?,
         @RequestParam(required = false) targetUserId: Long?
+        @RequestParam(required = false) status: List<ReportStatus>?,
     ): ResponseEntity<RsData<PageResponseDto<ReportSimpleResponseDto>>> {
+
+        val page = if (page < 1) 1 else page
+        val size = if (size < 1) 10 else size
+
         val pageable: Pageable = PageRequest.of(page - 1, size)
 
         val reportHistoryPage = reportService.getReportPage(pageable, status, targetUserId)
@@ -52,7 +57,7 @@ class ReportAdminController (
         return ResponseEntity.ok(
             RsData(
                 "200-1",
-                "${response.pageInfo.totalElements}개의 신고글을 발견했습니다.",
+                "${response.pageInfo.totalElements}개의 신고글 조회 완료.",
                 response
             )
         )

--- a/backend/src/main/java/com/bookbook/domain/report/service/ReportService.kt
+++ b/backend/src/main/java/com/bookbook/domain/report/service/ReportService.kt
@@ -93,18 +93,17 @@ class ReportService(
      * @param reportId 신고 글 ID
      * @param userId 처리 완료를 진행한 자의 ID
      * @throws ServiceException
+     * <p>(401) 허가되지 않은 접근
      * <p>(409) 처리가 완료된 신고를 다시 처리하고자 할 때
      * <p>(422) 대기 중인 신고를 처리 완료 상태로 바꾸고자 할 때
      */
     @Transactional
     fun markReportAsProcessed(reportId: Long, userId: Long) {
-        val report = findReportById(reportId)
-
         val closer = userService.findById(userId)
-            ?: throw ServiceException("404-1", "존재하지 않는 사용자입니다.")
+            ?. takeIf { it.isAdmin }
+            ?: throw ServiceException("401-1", "허가되지 않은 접근입니다 처리할 권한이 없습니다.")
 
-        if (!closer.isAdmin)
-            throw ServiceException("403-1", "신고를 처리할 권한이 없습니다.")
+        val report = findReportById(reportId)
 
         val status = report.status
 

--- a/backend/src/main/java/com/bookbook/global/extension/Extension.kt
+++ b/backend/src/main/java/com/bookbook/global/extension/Extension.kt
@@ -10,9 +10,7 @@ fun CustomOAuth2User?.requireAdmin(): CustomOAuth2User {
         this == null ||
         this.userId == -1L ||
         this.role != Role.ADMIN
-    ) {
-        throw ServiceException("401-1", "허가되지 않은 접근입니다.")
-    }
+    ) throw ServiceException("401-1", "허가되지 않은 접근입니다.")
 
     return this
 }

--- a/backend/src/main/java/com/bookbook/global/extension/Extension.kt
+++ b/backend/src/main/java/com/bookbook/global/extension/Extension.kt
@@ -1,0 +1,18 @@
+package com.bookbook.global.extension
+
+import com.bookbook.domain.user.enums.Role
+import com.bookbook.global.exception.ServiceException
+import com.bookbook.global.security.CustomOAuth2User
+
+
+fun CustomOAuth2User?.requireAdmin(): CustomOAuth2User {
+    if (
+        this == null ||
+        this.userId == -1L ||
+        this.role != Role.ADMIN
+    ) {
+        throw ServiceException("401-1", "허가되지 않은 접근입니다.")
+    }
+
+    return this
+}

--- a/backend/src/test/java/com/bookbook/TestSetup.kt
+++ b/backend/src/test/java/com/bookbook/TestSetup.kt
@@ -7,8 +7,10 @@ import com.bookbook.domain.user.enums.Role
 import com.bookbook.domain.user.repository.UserRepository
 import com.bookbook.global.security.CustomOAuth2User
 import jakarta.annotation.PostConstruct
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.core.GrantedAuthority
 import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Component
 import org.springframework.test.context.ActiveProfiles
@@ -21,8 +23,40 @@ class TestSetup (
     private val userRepository: UserRepository,
     private val suspendedUserRepository: SuspendedUserRepository,
     private val passwordEncoder: PasswordEncoder
-
 ){
+    companion object {
+        fun setAuthentication(user: User) {
+            val customUser = createCustomOAuth2User(user)
+
+            val authentication = UsernamePasswordAuthenticationToken(
+                customUser, null, customUser.authorities
+            )
+
+            SecurityContextHolder.getContext().authentication = authentication
+        }
+
+        fun createCustomOAuth2User(user: User): CustomOAuth2User {
+            val authorities: Collection<GrantedAuthority> = listOf(SimpleGrantedAuthority("ROLE_${user.role}"))
+
+            val attributes: Map<String, Any> = mapOf<String, Any>(
+                "id" to user.id,
+                "name" to user.username,
+                "email" to user.email.orEmpty()
+            )
+            val nameAttributeKey = "name"
+
+            return CustomOAuth2User(
+                authorities,
+                attributes,
+                nameAttributeKey,
+                username = user.username,
+                nickname = user.nickname,
+                userId = user.id,
+                isRegistrationCompleted = user.isRegistrationCompleted(),
+                role = user.role
+            )
+        }
+    }
 
     @Transactional
     @PostConstruct

--- a/backend/src/test/java/com/bookbook/TestSetup.kt
+++ b/backend/src/test/java/com/bookbook/TestSetup.kt
@@ -111,24 +111,6 @@ class TestSetup (
     }
 
     fun createCustomOAuth2User(user: User): CustomOAuth2User {
-        val authorities: Collection<GrantedAuthority> = listOf(SimpleGrantedAuthority("ROLE_${user.role}"))
-
-        val attributes: Map<String, Any> = mapOf<String, Any>(
-            "id" to user.id,
-            "name" to user.username,
-            "email" to user.email.orEmpty()
-        )
-        val nameAttributeKey = "name"
-
-        return CustomOAuth2User(
-            authorities,
-            attributes,
-            nameAttributeKey,
-            username = user.username,
-            nickname = user.nickname,
-            userId = user.id,
-            isRegistrationCompleted = user.isRegistrationCompleted(),
-            role = user.role
-        )
+        return Companion.createCustomOAuth2User(user)
     }
 }

--- a/backend/src/test/java/com/bookbook/domain/report/controller/ReportAdminControllerTest.kt
+++ b/backend/src/test/java/com/bookbook/domain/report/controller/ReportAdminControllerTest.kt
@@ -2,7 +2,6 @@ package com.bookbook.domain.report.controller
 
 import com.bookbook.TestSetup
 import com.bookbook.domain.report.enums.ReportStatus
-import com.bookbook.domain.report.repository.ReportRepository
 import com.bookbook.domain.report.service.ReportService
 import com.bookbook.domain.user.entity.User
 import com.bookbook.domain.user.repository.UserRepository
@@ -14,7 +13,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.data.domain.PageRequest
 import org.springframework.security.core.context.SecurityContextHolder
-import org.springframework.security.test.context.support.WithMockUser
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
@@ -25,11 +23,10 @@ import org.springframework.transaction.annotation.Transactional
 
 @ActiveProfiles("test")
 @SpringBootTest
+@DisplayName("ReportAdminController 통합 테스트")
 @AutoConfigureMockMvc(addFilters = false)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @Transactional
-@WithMockUser(roles = ["ADMIN"])
-@DisplayName("ReportAdminController 통합 테스트")
 class ReportAdminControllerTest {
 
     @Autowired
@@ -37,9 +34,6 @@ class ReportAdminControllerTest {
 
     @Autowired
     private lateinit var reportService: ReportService
-
-    @Autowired
-    private lateinit var reportRepository: ReportRepository
 
     @Autowired
     private lateinit var userRepository: UserRepository
@@ -68,10 +62,6 @@ class ReportAdminControllerTest {
                 target.id,
                 "이유 예시 $i"
             )
-
-            val found = reportRepository.findById(i.toLong())
-
-            if (found.isEmpty) continue
 
             if (i % 3 == 0)
                 reportService.getReportDetail(i.toLong())

--- a/backend/src/test/java/com/bookbook/domain/report/controller/ReportAdminControllerTest.kt
+++ b/backend/src/test/java/com/bookbook/domain/report/controller/ReportAdminControllerTest.kt
@@ -1,0 +1,345 @@
+package com.bookbook.domain.report.controller
+
+import com.bookbook.TestSetup
+import com.bookbook.domain.report.enums.ReportStatus
+import com.bookbook.domain.report.repository.ReportRepository
+import com.bookbook.domain.report.service.ReportService
+import com.bookbook.domain.user.entity.User
+import com.bookbook.domain.user.repository.UserRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.hamcrest.Matchers
+import org.junit.jupiter.api.*
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.data.domain.PageRequest
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers.print
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
+import org.springframework.transaction.annotation.Transactional
+
+@ActiveProfiles("test")
+@SpringBootTest
+@AutoConfigureMockMvc(addFilters = false)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@Transactional
+@WithMockUser(roles = ["ADMIN"])
+@DisplayName("ReportAdminController 통합 테스트")
+class ReportAdminControllerTest {
+
+    @Autowired
+    private lateinit var mvc: MockMvc
+
+    @Autowired
+    private lateinit var reportService: ReportService
+
+    @Autowired
+    private lateinit var reportRepository: ReportRepository
+
+    @Autowired
+    private lateinit var userRepository: UserRepository
+
+    private lateinit var reporterUser: User
+    private lateinit var targetUser: User
+    private lateinit var adminUser: User
+
+    @BeforeAll
+    fun beforeAll() {
+        adminUser = userRepository.findById(6).get()
+        reporterUser = userRepository.findById(2).get()
+        targetUser = userRepository.findById(3).get()
+
+        // 신고가 정상적으로 진행되었다는 가정 하에 진행합니다.
+
+        for (i in 1..12) {
+            val (reporter, target) = if (i % 2 == 0) {
+                Pair(reporterUser, targetUser)
+            } else {
+                Pair(targetUser, reporterUser)
+            }
+
+            reportService.createReport(
+                reporter.id,
+                target.id,
+                "이유 예시 $i"
+            )
+
+            val found = reportRepository.findById(i.toLong())
+
+            if (found.isEmpty) continue
+
+            if (i % 3 == 0)
+                reportService.getReportDetail(i.toLong())
+
+            if (i == 12)
+                reportService.markReportAsProcessed(i.toLong(), adminUser.id)
+        }
+    }
+
+    @BeforeEach
+    fun setUp() {
+        SecurityContextHolder.clearContext()
+        TestSetup.setAuthentication(adminUser)
+    }
+
+    @Test
+    @DisplayName("신고 목록 조회")
+    fun t1() {
+        val page = 1
+        val size = 10
+
+        val resultActions = mvc.perform(
+            get("/api/v1/admin/reports")
+            )
+            .andDo(print())
+
+        val pageable = PageRequest.of(page - 1, size)
+
+        val reportPage = reportService.getReportPage(pageable, null, null)
+        val reports = reportPage.content
+
+        resultActions
+            .andExpect(handler().handlerType(ReportAdminController::class.java))
+            .andExpect(handler().methodName("getReportPage"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.resultCode").value("200-1"))
+            .andExpect(jsonPath("$.msg").value("${reportPage.totalElements}개의 신고글 조회 완료."))
+            .andExpect(jsonPath("$.data").exists())
+
+        for (i in reports.indices) {
+            val report = reports[i]
+
+            resultActions
+                .andExpect(jsonPath("$.data.content[$i].id").value(report.id))
+                .andExpect(jsonPath("$.data.content[$i].status").value(report.status.toString()))
+                .andExpect(jsonPath("$.data.content[$i].reporterUserId").exists())
+                .andExpect(jsonPath("$.data.content[$i].targetUserId").exists())
+                .andExpect(jsonPath("$.data.content[$i].createdDate")
+                    .value(Matchers.startsWith(report.createdDate.toString().take(20)))
+                )
+        }
+    }
+
+    @Test
+    @DisplayName("신고 목록 조회 - 필터링 (상태)")
+    fun t2() {
+        val page = 1
+        val size = 10
+        val statuses = listOf(ReportStatus.REVIEWED, ReportStatus.PROCESSED)
+
+        val resultActions = mvc.perform(
+            get("/api/v1/admin/reports")
+                .apply {
+                    statuses.forEach {
+                        param("status", it.name)
+                    }
+                }
+            )
+            .andDo(print())
+
+        val pageable = PageRequest.of(page - 1, size)
+
+        val reportPage = reportService.getReportPage(pageable, statuses, null)
+        val reports = reportPage.content
+
+        resultActions
+            .andExpect(handler().handlerType(ReportAdminController::class.java))
+            .andExpect(handler().methodName("getReportPage"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.resultCode").value("200-1"))
+            .andExpect(jsonPath("$.data").exists())
+
+        for (i in reports.indices) {
+            val report = reports[i]
+
+            resultActions
+                .andExpect(jsonPath("$.data.content[$i].id").value(report.id))
+                .andExpect(jsonPath("$.data.content[$i].status")
+                    .value(Matchers.not(ReportStatus.PENDING.toString()))
+                )
+                .andExpect(jsonPath("$.data.content[$i].createdDate")
+                    .value(Matchers.startsWith(report.createdDate.toString().take(20)))
+                )
+        }
+    }
+
+    @Test
+    @DisplayName("신고 목록 조회 - 상태 필터링(신고 대상 ID)")
+    fun t3() {
+        val page = 1
+        val size = 10
+        val userId = targetUser.id
+
+        val resultActions = mvc.perform(
+            get("/api/v1/admin/reports")
+                .param("targetUserId", userId.toString())
+            )
+            .andDo(print())
+
+        val pageable = PageRequest.of(page - 1, size)
+
+        val reportPage = reportService.getReportPage(pageable, null, userId)
+        val reports = reportPage.content
+
+        resultActions
+            .andExpect(handler().handlerType(ReportAdminController::class.java))
+            .andExpect(handler().methodName("getReportPage"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.resultCode").value("200-1"))
+            .andExpect(jsonPath("$.data").exists())
+
+        for (i in reports.indices) {
+            val report = reports[i]
+
+            resultActions
+                .andExpect(jsonPath("$.data.content[$i].id").value(report.id))
+                .andExpect(jsonPath("$.data.content[$i].targetUserId").value(userId))
+                .andExpect(jsonPath("$.data.content[$i].createdDate")
+                    .value(Matchers.startsWith(report.createdDate.toString().take(20)))
+                )
+        }
+    }
+
+    @Test
+    @DisplayName("단일 신고 조회")
+    fun t4() {
+        val reportId = 1L
+
+        val resultActions = mvc.perform(
+            get("/api/v1/admin/reports/${reportId}/review")
+            )
+            .andDo(print())
+
+        val reportDetail = reportService.getReportDetail(reportId)
+
+        resultActions
+            .andExpect(handler().handlerType(ReportAdminController::class.java))
+            .andExpect(handler().methodName("getReportDetail"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.resultCode").value("200-1"))
+            .andExpect(jsonPath("$.msg").value("${reportId}번 신고글 조회 완료"))
+            .andExpect(jsonPath("$.data").exists())
+            .andExpect(jsonPath("$.data.id").value(reportId))
+            .andExpect(jsonPath("$.data.status").value(ReportStatus.REVIEWED.toString()))
+            .andExpect(jsonPath("$.data.reviewedDate")
+                .value(Matchers.startsWith(reportDetail.reviewedDate.toString().take(20)))
+            )
+    }
+
+    @Test
+    @DisplayName("단일 신고 처리 - 정상 진행")
+    fun t5() {
+        // 리뷰가 완료된 신고글의 Id
+        val reportId = 3L
+
+        // 처리 완료 진행
+        val resultActions = mvc.perform(
+            patch("/api/v1/admin/reports/${reportId}/process")
+            )
+            .andDo(print())
+
+        val report = reportService.findReportById(reportId)
+
+        resultActions
+            .andExpect(handler().handlerType(ReportAdminController::class.java))
+            .andExpect(handler().methodName("processReport"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.resultCode").value("200-1"))
+            .andExpect(jsonPath("$.msg").value("${reportId}번 신고가 정상적으로 처리되었습니다."))
+            .andExpect(jsonPath("$.data").doesNotExist())
+
+        assertThat(report.status).isEqualTo(ReportStatus.PROCESSED)
+        assertThat(report.closerId).isEqualTo(adminUser.id)
+    }
+
+    @Test
+    @DisplayName("단일 신고 처리 - 존재하지 않는 신고 ID")
+    fun t6() {
+        val reportId = 99L
+
+        // 처리 완료 진행
+        val resultActions = mvc.perform(
+            patch("/api/v1/admin/reports/${reportId}/process")
+            )
+            .andDo(print())
+
+        resultActions
+            .andExpect(handler().handlerType(ReportAdminController::class.java))
+            .andExpect(handler().methodName("processReport"))
+            .andExpect(status().isNotFound)
+            .andExpect(jsonPath("$.resultCode").value("404-1"))
+            .andExpect(jsonPath("$.msg").value("존재하지 않는 신고입니다."))
+            .andExpect(jsonPath("$.data").doesNotExist())
+    }
+
+    @Test
+    @DisplayName("단일 신고 처리 - 처리 대기 상태인 신고 처리")
+    fun t7() {
+        val reportId = 1L
+
+        // 처리 완료 진행
+        val resultActions = mvc.perform(
+            patch("/api/v1/admin/reports/${reportId}/process")
+            )
+            .andDo(print())
+
+        resultActions
+            .andExpect(handler().handlerType(ReportAdminController::class.java))
+            .andExpect(handler().methodName("processReport"))
+            .andExpect(status().isUnprocessableEntity)
+            .andExpect(jsonPath("$.resultCode").value("422-1"))
+            .andExpect(jsonPath("$.msg").value("해당 신고를 먼저 확인해야 합니다."))
+            .andExpect(jsonPath("$.data").doesNotExist())
+    }
+
+    @Test
+    @DisplayName("단일 신고 처리 - 처리를 완료한 신고를 다시 처리")
+    fun t8() {
+        val reportId = 3L
+
+        // 처리 완료 진행
+        mvc.perform(
+            patch("/api/v1/admin/reports/${reportId}/process")
+        ).andDo(print())
+
+        val resultActions = mvc.perform(
+            patch("/api/v1/admin/reports/${reportId}/process")
+            )
+            .andDo(print())
+
+        resultActions
+            .andExpect(handler().handlerType(ReportAdminController::class.java))
+            .andExpect(handler().methodName("processReport"))
+            .andExpect(status().isConflict)
+            .andExpect(jsonPath("$.resultCode").value("409-1"))
+            .andExpect(jsonPath("$.msg").value("해당 신고는 이미 처리가 완료되었습니다."))
+            .andExpect(jsonPath("$.data").doesNotExist())
+    }
+
+    @Test
+    @DisplayName("단일 신고 처리 - 일반 유저가 진행")
+    fun t9() {
+        val reportId = 3L
+
+        TestSetup.setAuthentication(targetUser)
+
+        // 처리 완료 진행
+        val resultActions = mvc.perform(
+            patch("/api/v1/admin/reports/${reportId}/process")
+            )
+            .andDo(print())
+
+        resultActions
+            .andExpect(handler().handlerType(ReportAdminController::class.java))
+            .andExpect(handler().methodName("processReport"))
+            .andExpect(status().isUnauthorized)
+            .andExpect(jsonPath("$.resultCode").value("401-1"))
+            .andExpect(jsonPath("$.msg").value("허가되지 않은 접근입니다."))
+            .andExpect(jsonPath("$.data").doesNotExist())
+    }
+}


### PR DESCRIPTION
## 💡 변경 사항
- [x] 테스트 케이스 추가
- [x] 확장 함수 추가
  * CustomOAuth2User 객체에 대해 admin 권한을 요구하는 로직을 추가했습니다.
- [x] TestSetup 수정
  * 아래 참고

---

### ✅ 특이 사항
#### - [x] TestSetup 수정
(1) createCustomOAuth2User 
* 함수가 두 개 선언되어 있는데, 정적 및 인스턴스 방식 모두 사용 가능하게 하기 위해서 입니다.

(2) SecuriyHolder 관련
* 테스트에서 SecuriyHolder 를 통해 인증 정보를 설정하는 중복 케이스가 발견되었습니다.
* 이에, 중복 감소 목적으로 정적 메소드 `setAuthentication`를 추가했습니다. User 엔티티 클래스를 인자로 받습니다.
```kotlin
// 공통 : user 변수는 User 엔티티와 관련된 부분입니다.

// 이전
val customOauth2User = testSetup.createCustomOAuth2User(user)
val auth = UsernamePasswordAuthenticationToken(
    customOauth2User, 
    null,
    customOauth2User.authorities
)
SecurityContextHolder.getContext().authentication = auth

// 제안
TestSetup.setAuthentication(user)

// 실제 케이스 예시
@BeforeEach
fun setUp() {
    SecurityContextHolder.clearContext()
    TestSetup.setAuthentication(adminUser)
}

// 타 테스트에서 다른 유저로 한 번 더 사용할 시, 인증정보 덮어쓰기가 가능합니다.
```

---
### 🔗 관련 이슈
closed #129 